### PR TITLE
ICFAR-351 TFTP protocol and URL is not set in Upload Repository field

### DIFF
--- a/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/core/Utils.java
+++ b/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/core/Utils.java
@@ -41,12 +41,7 @@ public class Utils {
     }
 
     public static boolean isValidUrl(String url) {
-        try {
-            new URL(url).toURI();
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
+        return urlValidator.isValid(url);
     }
 
     public static boolean isValidUrl(UploadProtocol protocol, String host) {

--- a/xconf-angular-admin/src/test/java/com/comcast/xconf/admin/validator/UrlValidatorTest.java
+++ b/xconf-angular-admin/src/test/java/com/comcast/xconf/admin/validator/UrlValidatorTest.java
@@ -38,6 +38,9 @@ public class UrlValidatorTest {
 
         valid = Utils.isValidUrl("https://www.abc.com");
         assertTrue(valid);
+
+        valid = Utils.isValidUrl("tftp://10.10.10.10");
+        assertTrue(valid);
     }
 
     @Test


### PR DESCRIPTION
changed back to user apache common validation library instead of creating `new URL()` instance to validate url.

there is no need to user another libraries.