### PR TITLE
ICFAR-418 Implement SSL changes in XConf OSS

### DIFF
--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraConfiguration.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraConfiguration.java
@@ -73,12 +73,12 @@ public class CassandraConfiguration {
     }
 
     protected Cluster cluster(String username, String password) {
-
-        Optional<RemoteEndpointAwareJdkSSLOptions> sslOptions = getSslOptions();
-
         Cluster.Builder clusterBuilder = Cluster.builder();
 
-        sslOptions.ifPresent(sslOption -> clusterBuilder.withSSL(sslOption));
+        if (cassandraSettings.isUseSsl()) {
+            Optional<RemoteEndpointAwareJdkSSLOptions> sslOptions = getSslOptions();
+            sslOptions.ifPresent(sslOption -> clusterBuilder.withSSL(sslOption));
+        }
 
         clusterBuilder.addContactPoints(cassandraSettings.getContactPoints())
                 .withPort(cassandraSettings.getPort())

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraConfiguration.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraConfiguration.java
@@ -39,7 +39,8 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.comcast.apps.dataaccess.config.SslSettings.*;
+import static com.comcast.apps.dataaccess.config.SslSettings.JKS;
+import static com.comcast.apps.dataaccess.config.SslSettings.SSL;
 
 
 @Configuration
@@ -125,11 +126,11 @@ public class CassandraConfiguration {
     }
 
     protected InputStream readKeystore() throws FileNotFoundException {
-        return readSecureStoreFileAsVaultProperty(sslSettings.getKeystorePath()) ? new ByteArrayInputStream(sslSettings.getDecodedKeystore()) : new FileInputStream(sslSettings.getKeystorePath());
+        return sslSettings.isKeystoreSetAsProperty() ? new ByteArrayInputStream(sslSettings.getDecodedKeystore()) : new FileInputStream(sslSettings.getKeystorePath());
     }
 
     protected InputStream readTruststore() throws FileNotFoundException {
-        return readSecureStoreFileAsVaultProperty(sslSettings.getTruststorePath()) ? new ByteArrayInputStream(sslSettings.getDecodedTruststore()) : new FileInputStream(sslSettings.getTruststorePath());
+        return sslSettings.isTruststoreSetAsProperty() ? new ByteArrayInputStream(sslSettings.getDecodedTruststore()) : new FileInputStream(sslSettings.getTruststorePath());
     }
 
     protected SSLContext initSslContext(InputStream truststoreInputStream, String truststorePassword, InputStream keystoreInputStream, String keystorePassword) throws Exception {

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraConfiguration.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraConfiguration.java
@@ -71,7 +71,7 @@ public class CassandraConfiguration {
 
     protected Cluster cluster(String username, String password) {
 
-        Optional<JdkSSLOptions> sslOptions = getSslOptions();
+        Optional<RemoteEndpointAwareJdkSSLOptions> sslOptions = getSslOptions();
 
         Cluster.Builder clusterBuilder = Cluster.builder();
 
@@ -95,12 +95,13 @@ public class CassandraConfiguration {
         return cluster;
     }
 
-    protected Optional<JdkSSLOptions> getSslOptions() {
-        JdkSSLOptions sslOptions = null;
+    protected Optional<RemoteEndpointAwareJdkSSLOptions> getSslOptions() {
+        RemoteEndpointAwareJdkSSLOptions sslOptions = null;
         try {
             SSLContext sslContext = getSSLContext(sslSettings.getTruststorePath(), sslSettings.getTruststorePassword(), sslSettings.getKeystorePath(), sslSettings.getKeystorePassword());
-            sslOptions = JdkSSLOptions.builder()
+            sslOptions = RemoteEndpointAwareJdkSSLOptions.builder()
                     .withSSLContext(sslContext)
+                    .withCipherSuites(sslSettings.getCipherSuites())
                     .build();
         } catch (Exception e) {
             LOGGER.error("SSL property exception", e);

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraConfiguration.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraConfiguration.java
@@ -120,6 +120,10 @@ public class CassandraConfiguration {
         KeyManagerFactory kmf = initKeyManagerFactory(ksf, keystorePassword);
 
         ctx.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+
+        tsf.close();
+        ksf.close();
+
         return ctx;
     }
 

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraSettings.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/CassandraSettings.java
@@ -58,6 +58,9 @@ public class CassandraSettings {
     @Value("${cassandra.localDataCenter:#{null}}")
     private String localDataCenter;
 
+    @Value("${cassandra.useSsl:false}")
+    private boolean useSsl;
+
     public CassandraSettings() {}
 
     public CassandraSettings(final CassandraSettings settings) {
@@ -142,5 +145,13 @@ public class CassandraSettings {
 
     public void setLocalDataCenter(String localDataCenter) {
         this.localDataCenter = localDataCenter;
+    }
+
+    public boolean isUseSsl() {
+        return useSsl;
+    }
+
+    public void setUseSsl(boolean useSsl) {
+        this.useSsl = useSsl;
     }
 }

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
@@ -38,8 +38,6 @@ public class SslSettings {
     public static final String JKS = "JKS";
     public static final String DEFAULT_SSL_CIPHER_SUITES = "TLS_RSA_WITH_AES_256_CBC_SHA";
 
-    private static final String VAULT_PREFIX = "vault";
-
     @Value("${ssl.authKey}")
     private String authKey;
 
@@ -127,8 +125,12 @@ public class SslSettings {
         return Base64.getDecoder().decode(getKeystore());
     }
 
-    public static boolean readSecureStoreFileAsVaultProperty(String path) {
-        return StringUtils.startsWith(path, VAULT_PREFIX);
+    public boolean isKeystoreSetAsProperty() {
+        return StringUtils.isNotBlank(getKeystore());
+    }
+
+    public boolean isTruststoreSetAsProperty() {
+        return StringUtils.isNotBlank(getTruststore());
     }
 
     @Override

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
@@ -53,10 +53,10 @@ public class SslSettings {
     @Value("${ssl.keystore.password}")
     private String keystorePassword;
 
-    @Value("${ssl.truststore}")
+    @Value("${ssl.truststore:}")
     private String truststore;
 
-    @Value("${ssl.keystore}")
+    @Value("${ssl.keystore:}")
     private String keystore;
 
     @Value("#{'${ssl.cipherSuites:TLS_RSA_WITH_AES_256_CBC_SHA}'.split(',')}")

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
@@ -1,0 +1,101 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2021 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Maksym Dolina (mdolina@productengine.com)
+ */
+package com.comcast.apps.dataaccess.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@PropertySource(
+        value = {"classpath:service.properties", "file:${appConfig}"}, ignoreResourceNotFound = true)
+public class SslSettings {
+
+    public static final String SSL = "SSL";
+    public static final String JKS = "JKS";
+
+    @Value("${ssl.truststore.path}")
+    private String truststorePath;
+
+    @Value("${ssl.truststore.password}")
+    private String truststorePassword;
+
+    @Value("${ssl.keystore.path}")
+    private String keystorePath;
+
+    @Value("${ssl.keystore.password}")
+    private String keystorePassword;
+
+    public String getTruststorePath() {
+        return truststorePath;
+    }
+
+    public void setTruststorePath(String truststorePath) {
+        this.truststorePath = truststorePath;
+    }
+
+    public String getTruststorePassword() {
+        return truststorePassword;
+    }
+
+    public void setTruststorePassword(String truststorePassword) {
+        this.truststorePassword = truststorePassword;
+    }
+
+    public String getKeystorePath() {
+        return keystorePath;
+    }
+
+    public void setKeystorePath(String keystorePath) {
+        this.keystorePath = keystorePath;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public void setKeystorePassword(String keystorePassword) {
+        this.keystorePassword = keystorePassword;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SslSettings that = (SslSettings) o;
+        return Objects.equals(truststorePath, that.truststorePath) && Objects.equals(truststorePassword, that.truststorePassword) && Objects.equals(keystorePath, that.keystorePath) && Objects.equals(keystorePassword, that.keystorePassword);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(truststorePath, truststorePassword, keystorePath, keystorePassword);
+    }
+
+    @Override
+    public String toString() {
+        return "SslSettings{" +
+                "truststorePath='" + truststorePath + '\'' +
+                ", keystorePath='" + keystorePath + '\'' +
+                '}';
+    }
+}

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
@@ -58,7 +58,7 @@ public class SslSettings {
     @Value("${ssl.truststore}")
     private String truststore;
 
-    @Value("${ssl.keystore:}")
+    @Value("${ssl.keystore}")
     private String keystore;
 
     @Value("#{'${ssl.cipherSuites:TLS_RSA_WITH_AES_256_CBC_SHA}'.split(',')}")

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
@@ -20,11 +20,13 @@
  */
 package com.comcast.apps.dataaccess.config;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Objects;
 
 @Component
@@ -35,6 +37,11 @@ public class SslSettings {
     public static final String SSL = "SSL";
     public static final String JKS = "JKS";
     public static final String DEFAULT_SSL_CIPHER_SUITES = "TLS_RSA_WITH_AES_256_CBC_SHA";
+
+    private static final String VAULT_PREFIX = "vault";
+
+    @Value("${ssl.authKey}")
+    private String authKey;
 
     @Value("${ssl.truststore.path}")
     private String truststorePath;
@@ -48,8 +55,22 @@ public class SslSettings {
     @Value("${ssl.keystore.password}")
     private String keystorePassword;
 
+    @Value("${ssl.truststore}")
+    private String truststore;
+
+    @Value("${ssl.keystore:}")
+    private String keystore;
+
     @Value("#{'${ssl.cipherSuites:TLS_RSA_WITH_AES_256_CBC_SHA}'.split(',')}")
     private String[] cipherSuites;
+
+    public String getAuthKey() {
+        return authKey;
+    }
+
+    public void setAuthKey(String authKey) {
+        this.authKey = authKey;
+    }
 
     public String getTruststorePath() {
         return truststorePath;
@@ -91,17 +112,36 @@ public class SslSettings {
         this.cipherSuites = cipherSuites;
     }
 
+    public String getTruststore() {
+        return this.truststore;
+    }
+
+    public String getKeystore() {
+        return this.keystore;
+    }
+    public byte[] getDecodedTruststore() {
+        return Base64.getDecoder().decode(getTruststore());
+    }
+
+    public byte[] getDecodedKeystore() {
+        return Base64.getDecoder().decode(getKeystore());
+    }
+
+    public static boolean readSecureStoreFileAsVaultProperty(String path) {
+        return StringUtils.startsWith(path, VAULT_PREFIX);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SslSettings that = (SslSettings) o;
-        return Objects.equals(truststorePath, that.truststorePath) && Objects.equals(truststorePassword, that.truststorePassword) && Objects.equals(keystorePath, that.keystorePath) && Objects.equals(keystorePassword, that.keystorePassword) && Arrays.equals(cipherSuites, that.cipherSuites);
+        return Objects.equals(authKey, that.authKey) && Objects.equals(truststorePath, that.truststorePath) && Objects.equals(truststorePassword, that.truststorePassword) && Objects.equals(keystorePath, that.keystorePath) && Objects.equals(keystorePassword, that.keystorePassword) && Arrays.equals(cipherSuites, that.cipherSuites);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(truststorePath, truststorePassword, keystorePath, keystorePassword);
+        int result = Objects.hash(authKey, truststorePath, truststorePassword, keystorePath, keystorePassword);
         result = 31 * result + Arrays.hashCode(cipherSuites);
         return result;
     }

--- a/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
+++ b/dataaccess2/src/main/java/com/comcast/apps/dataaccess/config/SslSettings.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 @Component
@@ -33,6 +34,7 @@ public class SslSettings {
 
     public static final String SSL = "SSL";
     public static final String JKS = "JKS";
+    public static final String DEFAULT_SSL_CIPHER_SUITES = "TLS_RSA_WITH_AES_256_CBC_SHA";
 
     @Value("${ssl.truststore.path}")
     private String truststorePath;
@@ -45,6 +47,9 @@ public class SslSettings {
 
     @Value("${ssl.keystore.password}")
     private String keystorePassword;
+
+    @Value("#{'${ssl.cipherSuites:TLS_RSA_WITH_AES_256_CBC_SHA}'.split(',')}")
+    private String[] cipherSuites;
 
     public String getTruststorePath() {
         return truststorePath;
@@ -78,17 +83,27 @@ public class SslSettings {
         this.keystorePassword = keystorePassword;
     }
 
+    public String[] getCipherSuites() {
+        return cipherSuites;
+    }
+
+    public void setCipherSuites(String[] cipherSuites) {
+        this.cipherSuites = cipherSuites;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SslSettings that = (SslSettings) o;
-        return Objects.equals(truststorePath, that.truststorePath) && Objects.equals(truststorePassword, that.truststorePassword) && Objects.equals(keystorePath, that.keystorePath) && Objects.equals(keystorePassword, that.keystorePassword);
+        return Objects.equals(truststorePath, that.truststorePath) && Objects.equals(truststorePassword, that.truststorePassword) && Objects.equals(keystorePath, that.keystorePath) && Objects.equals(keystorePassword, that.keystorePassword) && Arrays.equals(cipherSuites, that.cipherSuites);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(truststorePath, truststorePassword, keystorePath, keystorePassword);
+        int result = Objects.hash(truststorePath, truststorePassword, keystorePath, keystorePassword);
+        result = 31 * result + Arrays.hashCode(cipherSuites);
+        return result;
     }
 
     @Override
@@ -96,6 +111,7 @@ public class SslSettings {
         return "SslSettings{" +
                 "truststorePath='" + truststorePath + '\'' +
                 ", keystorePath='" + keystorePath + '\'' +
+                ", cipherSuites=" + Arrays.toString(cipherSuites) +
                 '}';
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     	<cglib>3.1</cglib>
     	<snappy>0.3</snappy>
     	<asm>5.0.2</asm>
-        <datastax.cassandra.version>3.1.3</datastax.cassandra.version>
+        <datastax.cassandra.version>3.10.0</datastax.cassandra.version>
     	<kryo-shaded>3.0.0</kryo-shaded>
     	<kryo-serializers>0.27</kryo-serializers>
         <slf4j.version>1.7.5</slf4j.version>

--- a/xconf-angular-admin/src/main/resources/sample.service.properties
+++ b/xconf-angular-admin/src/main/resources/sample.service.properties
@@ -49,3 +49,5 @@ ssl.truststore.path=/path/to/truststore.file
 ssl.truststore.password=securePassword
 ssl.keystore.path=/path/to/keystore.file
 ssl.keystore.password=securePassword
+ssl.cipherSuites=TLS_RSA_WITH_AES_256_CBC_SHA
+#if ssl.cipherSuites is missed default value is TLS_RSA_WITH_AES_256_CBC_SHA

--- a/xconf-angular-admin/src/main/resources/sample.service.properties
+++ b/xconf-angular-admin/src/main/resources/sample.service.properties
@@ -42,3 +42,10 @@ cassandra.password=
 cassandra.authKey=
 
 dataaccess.cache.changedKeysCfName=XconfChangedKeys
+
+######################## Cassandra SSL properties ICFAR-417 ########################
+
+ssl.truststore.path=/path/to/truststore.file
+ssl.truststore.password=securePassword
+ssl.keystore.path=/path/to/keystore.file
+ssl.keystore.password=securePassword

--- a/xconf-dataservice/src/main/resources/sample.service.properties
+++ b/xconf-dataservice/src/main/resources/sample.service.properties
@@ -44,10 +44,13 @@ cassandra.authKey=
 dataaccess.cache.changedKeysCfName=XconfChangedKeys
 
 ######################## Cassandra SSL properties ICFAR-417 ########################
+cassandra.useSsl=false
 
 ssl.truststore.path=/path/to/truststore.file
 ssl.truststore.password=securePassword
+ssl.truststore= encoded base64 truststore
 ssl.keystore.path=/path/to/keystore.file
 ssl.keystore.password=securePassword
+ssl.keystore= - encoded base64 keystore
 ssl.cipherSuites=TLS_RSA_WITH_AES_256_CBC_SHA
 #if ssl.cipherSuites is missed default value is TLS_RSA_WITH_AES_256_CBC_SHA

--- a/xconf-dataservice/src/main/resources/sample.service.properties
+++ b/xconf-dataservice/src/main/resources/sample.service.properties
@@ -42,3 +42,12 @@ cassandra.password=
 cassandra.authKey=
 
 dataaccess.cache.changedKeysCfName=XconfChangedKeys
+
+######################## Cassandra SSL properties ICFAR-417 ########################
+
+ssl.truststore.path=/path/to/truststore.file
+ssl.truststore.password=securePassword
+ssl.keystore.path=/path/to/keystore.file
+ssl.keystore.password=securePassword
+ssl.cipherSuites=TLS_RSA_WITH_AES_256_CBC_SHA
+#if ssl.cipherSuites is missed default value is TLS_RSA_WITH_AES_256_CBC_SHA


### PR DESCRIPTION
Added SSL option to cassandra connection.

To work that properly should be set:
- truststore path
- truststore password
- keystore path 
- keystore password
- cassandra should be configured to support ssl connection

To read `keystore` by file path `ssl.keystore.path` property should be specified in `service.properties` file and `ssl.keystore` property should be empty: `ssl.keystore=` or not specified at all, otherwise `keystore` is read from property file. The same rule is applied for `truststore`.