### PR TITLE
ICFAR-447 Percent Filter Rule With No ENV Causes Null Pointer Exception

### DIFF
--- a/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/EnvModelRuleQueriesController.java
+++ b/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/EnvModelRuleQueriesController.java
@@ -124,8 +124,8 @@ public class EnvModelRuleQueriesController extends BaseQueriesController {
             if (ruleBean.getName().equalsIgnoreCase(bean.getName()) && !ruleBean.getId().equalsIgnoreCase(bean.getId())) {
                 return new ResponseEntity<>("Name is already used", HttpStatus.BAD_REQUEST);
             }
-            if (ruleBean.getEnvironmentId().equalsIgnoreCase(bean.getEnvironmentId()) &&
-                    ruleBean.getModelId().equalsIgnoreCase(bean.getModelId())) {
+            if (StringUtils.equalsIgnoreCase(ruleBean.getEnvironmentId(), bean.getEnvironmentId())
+                    && StringUtils.equalsIgnoreCase(ruleBean.getModelId(), bean.getModelId())) {
                 return new ResponseEntity<>("Env/Model overlap with rule: " + ruleBean.getName(), HttpStatus.BAD_REQUEST);
             }
         }

--- a/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/EnvModelRuleQueriesControllerTest.java
+++ b/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/EnvModelRuleQueriesControllerTest.java
@@ -113,6 +113,25 @@ public class EnvModelRuleQueriesControllerTest extends BaseQueriesControllerTest
     }
 
     @Test
+    public void addEnvironmentToEnvModelRule() throws Exception {
+        EnvModelRuleBean envModelRuleBean = createDefaultEnvModelRuleBean();
+        envModelRuleBean.setEnvironmentId(null);
+        envModelRuleService.save(envModelRuleBean, STB);
+
+        assertNull(envModelRuleService.getOne(envModelRuleBean.getId()).getEnvironmentId());
+
+        EnvModelRuleBean envModelRuleBeanWithEnvironment = createDefaultEnvModelRuleBean();
+
+        mockMvc.perform(post("/" + QueryConstants.UPDATE_RULES_ENV_MODEL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JsonUtil.toJson(envModelRuleBeanWithEnvironment)))
+                .andExpect(status().isOk());
+
+        assertEquals(envModelRuleBean, envModelRuleService.getOne(envModelRuleBeanWithEnvironment.getId()));
+        assertEquals(defaultEnvironmentId.toUpperCase(), envModelRuleService.getOne(envModelRuleBeanWithEnvironment.getId()).getEnvironmentId());
+    }
+
+    @Test
     public void deleteEnvModelTest() throws Exception {
         EnvModelRuleBean bean = createDefaultEnvModelRuleBean();
         envModelRuleService.save(bean, STB);


### PR DESCRIPTION
- wrapped string comparison by `StringUtils.equalsIgnoreCase()` method