### PR TITLE
added ability to add key-value parameters to FirmwareConfig

### DIFF
--- a/dataaccess2/pom.xml
+++ b/dataaccess2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2-SNAPSHOT</version>
     </parent>
 
     <name>DataAccess2</name>

--- a/dataaccess2/pom.xml
+++ b/dataaccess2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.3</version>
     </parent>
 
     <name>DataAccess2</name>

--- a/dataaccess2/pom.xml
+++ b/dataaccess2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
 
     <name>DataAccess2</name>

--- a/dataaccess2/pom.xml
+++ b/dataaccess2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.2.3</version>
     </parent>
 
     <name>DataAccess2</name>

--- a/dataaccess2/pom.xml
+++ b/dataaccess2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
 
     <name>DataAccess2</name>

--- a/dataaccess2/pom.xml
+++ b/dataaccess2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <name>DataAccess2</name>

--- a/dataaccess2/pom.xml
+++ b/dataaccess2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.3.2</version>
     </parent>
 
     <name>DataAccess2</name>

--- a/dataaccess2/pom.xml
+++ b/dataaccess2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3-SNAPSHOT</version>
     </parent>
 
     <name>DataAccess2</name>

--- a/health-check/pom.xml
+++ b/health-check/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3-SNAPSHOT</version>
     </parent>
 
     <name>Health Check</name>

--- a/health-check/pom.xml
+++ b/health-check/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.2.3</version>
     </parent>
 
     <name>Health Check</name>

--- a/health-check/pom.xml
+++ b/health-check/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2-SNAPSHOT</version>
     </parent>
 
     <name>Health Check</name>

--- a/health-check/pom.xml
+++ b/health-check/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.3.2</version>
     </parent>
 
     <name>Health Check</name>

--- a/health-check/pom.xml
+++ b/health-check/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <name>Health Check</name>

--- a/health-check/pom.xml
+++ b/health-check/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
 
     <name>Health Check</name>

--- a/health-check/pom.xml
+++ b/health-check/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
 
     <name>Health Check</name>

--- a/health-check/pom.xml
+++ b/health-check/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.3</version>
     </parent>
 
     <name>Health Check</name>

--- a/hydra-astyanax-common/pom.xml
+++ b/hydra-astyanax-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
          <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
 
     <name>Hydra Astyanax Common Classes</name>

--- a/hydra-astyanax-common/pom.xml
+++ b/hydra-astyanax-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
          <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <name>Hydra Astyanax Common Classes</name>

--- a/hydra-astyanax-common/pom.xml
+++ b/hydra-astyanax-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
          <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.3.2</version>
     </parent>
 
     <name>Hydra Astyanax Common Classes</name>

--- a/hydra-astyanax-common/pom.xml
+++ b/hydra-astyanax-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
          <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.3</version>
     </parent>
 
     <name>Hydra Astyanax Common Classes</name>

--- a/hydra-astyanax-common/pom.xml
+++ b/hydra-astyanax-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
          <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.2.3</version>
     </parent>
 
     <name>Hydra Astyanax Common Classes</name>

--- a/hydra-astyanax-common/pom.xml
+++ b/hydra-astyanax-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
          <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
 
     <name>Hydra Astyanax Common Classes</name>

--- a/hydra-astyanax-common/pom.xml
+++ b/hydra-astyanax-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
          <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3-SNAPSHOT</version>
     </parent>
 
     <name>Hydra Astyanax Common Classes</name>

--- a/hydra-astyanax-common/pom.xml
+++ b/hydra-astyanax-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
          <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2-SNAPSHOT</version>
     </parent>
 
     <name>Hydra Astyanax Common Classes</name>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <name>XConf OSS</name>
     <groupId>com.comcast.coast.xconf.oss</groupId>
     <artifactId>xconf</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.2.3</version>
     <packaging>pom</packaging>
 
     <scm>
         <connection>scm:git:ssh://git@github.com:rdkcentral/xconfserver.git</connection>
-        <tag>HEAD</tag>
+        <tag>v1.2.3</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <name>XConf OSS</name>
     <groupId>com.comcast.coast.xconf.oss</groupId>
     <artifactId>xconf</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>
         <connection>scm:git:ssh://git@github.com:rdkcentral/xconfserver.git</connection>
-        <tag>v1.3.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <name>XConf OSS</name>
     <groupId>com.comcast.coast.xconf.oss</groupId>
     <artifactId>xconf</artifactId>
-    <version>1.3.3-SNAPSHOT</version>
+    <version>1.3.3</version>
     <packaging>pom</packaging>
 
     <scm>
         <connection>scm:git:ssh://git@github.com:rdkcentral/xconfserver.git</connection>
-        <tag>HEAD</tag>
+        <tag>v1.3.3</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <name>XConf OSS</name>
     <groupId>com.comcast.coast.xconf.oss</groupId>
     <artifactId>xconf</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>
         <connection>scm:git:ssh://git@github.com:rdkcentral/xconfserver.git</connection>
-        <tag>v1.3.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <name>XConf OSS</name>
     <groupId>com.comcast.coast.xconf.oss</groupId>
     <artifactId>xconf</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>
         <connection>scm:git:ssh://git@github.com:rdkcentral/xconfserver.git</connection>
-        <tag>v1.3.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <name>XConf OSS</name>
     <groupId>com.comcast.coast.xconf.oss</groupId>
     <artifactId>xconf</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>
         <connection>scm:git:ssh://git@github.com:rdkcentral/xconfserver.git</connection>
-        <tag>v1.2.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <name>XConf OSS</name>
     <groupId>com.comcast.coast.xconf.oss</groupId>
     <artifactId>xconf</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.1</version>
     <packaging>pom</packaging>
 
     <scm>
         <connection>scm:git:ssh://git@github.com:rdkcentral/xconfserver.git</connection>
-        <tag>HEAD</tag>
+        <tag>v1.3.1</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <name>XConf OSS</name>
     <groupId>com.comcast.coast.xconf.oss</groupId>
     <artifactId>xconf</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>1.3.2</version>
     <packaging>pom</packaging>
 
     <scm>
         <connection>scm:git:ssh://git@github.com:rdkcentral/xconfserver.git</connection>
-        <tag>HEAD</tag>
+        <tag>v1.3.2</tag>
     </scm>
 
     <properties>

--- a/rules-engine/pom.xml
+++ b/rules-engine/pom.xml
@@ -22,7 +22,7 @@
      <parent>
     	<groupId>com.comcast.coast.xconf.oss</groupId>
     	<artifactId>xconf</artifactId>
-       <version>1.3.2</version>
+       <version>1.3.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rules-engine/pom.xml
+++ b/rules-engine/pom.xml
@@ -22,7 +22,7 @@
      <parent>
     	<groupId>com.comcast.coast.xconf.oss</groupId>
     	<artifactId>xconf</artifactId>
-       <version>1.3.3-SNAPSHOT</version>
+       <version>1.3.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rules-engine/pom.xml
+++ b/rules-engine/pom.xml
@@ -22,7 +22,7 @@
      <parent>
     	<groupId>com.comcast.coast.xconf.oss</groupId>
     	<artifactId>xconf</artifactId>
-       <version>1.2.3</version>
+       <version>1.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rules-engine/pom.xml
+++ b/rules-engine/pom.xml
@@ -22,7 +22,7 @@
      <parent>
     	<groupId>com.comcast.coast.xconf.oss</groupId>
     	<artifactId>xconf</artifactId>
-       <version>1.3.2-SNAPSHOT</version>
+       <version>1.3.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rules-engine/pom.xml
+++ b/rules-engine/pom.xml
@@ -22,7 +22,7 @@
      <parent>
     	<groupId>com.comcast.coast.xconf.oss</groupId>
     	<artifactId>xconf</artifactId>
-       <version>1.3.3</version>
+       <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rules-engine/pom.xml
+++ b/rules-engine/pom.xml
@@ -22,7 +22,7 @@
      <parent>
     	<groupId>com.comcast.coast.xconf.oss</groupId>
     	<artifactId>xconf</artifactId>
-       <version>1.3.1</version>
+       <version>1.3.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rules-engine/pom.xml
+++ b/rules-engine/pom.xml
@@ -22,7 +22,7 @@
      <parent>
     	<groupId>com.comcast.coast.xconf.oss</groupId>
     	<artifactId>xconf</artifactId>
-       <version>1.3.1-SNAPSHOT</version>
+       <version>1.3.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/rules-engine/pom.xml
+++ b/rules-engine/pom.xml
@@ -22,7 +22,7 @@
      <parent>
     	<groupId>com.comcast.coast.xconf.oss</groupId>
     	<artifactId>xconf</artifactId>
-       <version>1.2.3-SNAPSHOT</version>
+       <version>1.2.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/xconf-angular-admin/pom.xml
+++ b/xconf-angular-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
 
     <name>xconf-angular-admin</name>

--- a/xconf-angular-admin/pom.xml
+++ b/xconf-angular-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.2.3</version>
     </parent>
 
     <name>xconf-angular-admin</name>

--- a/xconf-angular-admin/pom.xml
+++ b/xconf-angular-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
 
     <name>xconf-angular-admin</name>

--- a/xconf-angular-admin/pom.xml
+++ b/xconf-angular-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.3.2</version>
     </parent>
 
     <name>xconf-angular-admin</name>

--- a/xconf-angular-admin/pom.xml
+++ b/xconf-angular-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
 
     <name>xconf-angular-admin</name>

--- a/xconf-angular-admin/pom.xml
+++ b/xconf-angular-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.3</version>
     </parent>
 
     <name>xconf-angular-admin</name>

--- a/xconf-angular-admin/pom.xml
+++ b/xconf-angular-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2-SNAPSHOT</version>
     </parent>
 
     <name>xconf-angular-admin</name>

--- a/xconf-angular-admin/pom.xml
+++ b/xconf-angular-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3-SNAPSHOT</version>
     </parent>
 
     <name>xconf-angular-admin</name>

--- a/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/validator/firmware/FirmwareConfigValidator.java
+++ b/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/validator/firmware/FirmwareConfigValidator.java
@@ -40,6 +40,9 @@ import java.util.Map;
 @Component
 public class FirmwareConfigValidator implements IValidator<FirmwareConfig> {
 
+    public static final String MAX_ALLOWED_NUMBER_OF_PROPERTIES_ERR_MSG_TEMPLATE = "Max allowed number of properties is %s";
+    public static final int MAX_ALLOWED_NUMBER_OF_PROPERTIES = 20;
+
     @Autowired
     private FirmwarePermissionService permissionService;
 
@@ -67,7 +70,8 @@ public class FirmwareConfigValidator implements IValidator<FirmwareConfig> {
             throw new ValidationRuntimeException("Application type is empty");
         }
 
-        validateParameters(firmwareConfig.getProperties());
+        validatePropertyKeys(firmwareConfig.getProperties());
+        validatePropertiesSize(firmwareConfig.getProperties());
 
         PermissionHelper.validateWrite(permissionService, firmwareConfig.getApplicationType());
 
@@ -87,13 +91,19 @@ public class FirmwareConfigValidator implements IValidator<FirmwareConfig> {
         }
     }
 
-    private void validateParameters(Map<String, String> parameters) {
+    private void validatePropertyKeys(Map<String, String> parameters) {
         if (MapUtils.isNotEmpty(parameters)) {
             for (Map.Entry<String, String> parameter : parameters.entrySet()) {
                 if (StringUtils.isBlank(parameter.getKey())) {
                     throw new ValidationRuntimeException("Key is empty");
                 }
             }
+        }
+    }
+
+    private void validatePropertiesSize(Map<String, String> properties) {
+        if (MapUtils.isNotEmpty(properties) && properties.size() > MAX_ALLOWED_NUMBER_OF_PROPERTIES) {
+            throw new ValidationRuntimeException(String.format(MAX_ALLOWED_NUMBER_OF_PROPERTIES_ERR_MSG_TEMPLATE, MAX_ALLOWED_NUMBER_OF_PROPERTIES));
         }
     }
 }

--- a/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/validator/firmware/FirmwareConfigValidator.java
+++ b/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/validator/firmware/FirmwareConfigValidator.java
@@ -70,7 +70,7 @@ public class FirmwareConfigValidator implements IValidator<FirmwareConfig> {
             throw new ValidationRuntimeException("Application type is empty");
         }
 
-        validatePropertyKeys(firmwareConfig.getProperties());
+        validatePropertiesDoNotHaveEmptyValues(firmwareConfig.getProperties());
         validatePropertiesSize(firmwareConfig.getProperties());
 
         PermissionHelper.validateWrite(permissionService, firmwareConfig.getApplicationType());
@@ -91,11 +91,14 @@ public class FirmwareConfigValidator implements IValidator<FirmwareConfig> {
         }
     }
 
-    private void validatePropertyKeys(Map<String, String> parameters) {
+    private void validatePropertiesDoNotHaveEmptyValues(Map<String, String> parameters) {
         if (MapUtils.isNotEmpty(parameters)) {
             for (Map.Entry<String, String> parameter : parameters.entrySet()) {
                 if (StringUtils.isBlank(parameter.getKey())) {
                     throw new ValidationRuntimeException("Key is empty");
+                }
+                if (StringUtils.isBlank(parameter.getValue())) {
+                    throw new ValidationRuntimeException("Value is blank for key: " + parameter.getKey());
                 }
             }
         }

--- a/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/validator/firmware/FirmwareConfigValidator.java
+++ b/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/validator/firmware/FirmwareConfigValidator.java
@@ -67,7 +67,7 @@ public class FirmwareConfigValidator implements IValidator<FirmwareConfig> {
             throw new ValidationRuntimeException("Application type is empty");
         }
 
-        validateParameters(firmwareConfig.getParameters());
+        validateParameters(firmwareConfig.getProperties());
 
         PermissionHelper.validateWrite(permissionService, firmwareConfig.getApplicationType());
 

--- a/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/validator/firmware/FirmwareConfigValidator.java
+++ b/xconf-angular-admin/src/main/java/com/comcast/xconf/admin/validator/firmware/FirmwareConfigValidator.java
@@ -21,18 +21,21 @@
  */
 package com.comcast.xconf.admin.validator.firmware;
 
-import com.comcast.xconf.exception.EntityConflictException;
 import com.comcast.apps.dataaccess.support.exception.ValidationRuntimeException;
 import com.comcast.xconf.estbfirmware.FirmwareConfig;
 import com.comcast.xconf.estbfirmware.ModelQueriesService;
+import com.comcast.xconf.exception.EntityConflictException;
 import com.comcast.xconf.firmware.ApplicationType;
 import com.comcast.xconf.permissions.FirmwarePermissionService;
 import com.comcast.xconf.permissions.PermissionHelper;
 import com.comcast.xconf.validators.IValidator;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 @Component
 public class FirmwareConfigValidator implements IValidator<FirmwareConfig> {
@@ -64,6 +67,8 @@ public class FirmwareConfigValidator implements IValidator<FirmwareConfig> {
             throw new ValidationRuntimeException("Application type is empty");
         }
 
+        validateParameters(firmwareConfig.getParameters());
+
         PermissionHelper.validateWrite(permissionService, firmwareConfig.getApplicationType());
 
         for (String modelId : firmwareConfig.getSupportedModelIds()) {
@@ -78,6 +83,16 @@ public class FirmwareConfigValidator implements IValidator<FirmwareConfig> {
         for (final FirmwareConfig entity : existingEntities) {
             if (ApplicationType.equals(firmwareConfig.getApplicationType(), entity.getApplicationType()) && !entity.getId().equals(firmwareConfig.getId()) && entity.getDescription().equalsIgnoreCase(firmwareConfig.getDescription())) {
                 throw new EntityConflictException("This description " + firmwareConfig.getDescription() + " is already used");
+            }
+        }
+    }
+
+    private void validateParameters(Map<String, String> parameters) {
+        if (MapUtils.isNotEmpty(parameters)) {
+            for (Map.Entry<String, String> parameter : parameters.entrySet()) {
+                if (StringUtils.isBlank(parameter.getKey())) {
+                    throw new ValidationRuntimeException("Key is empty");
+                }
             }
         }
     }

--- a/xconf-angular-admin/src/main/webapp/WEB-INF/jsp/xconfindex.jsp
+++ b/xconf-angular-admin/src/main/webapp/WEB-INF/jsp/xconfindex.jsp
@@ -50,6 +50,7 @@
             <link href="<c:url value="/app/xconf/xconf_base.css"/>" rel="stylesheet" />
             <link href="<c:url value="/app/shared/styles/shared.css"/>" rel="stylesheet" />
             <link href="<c:url value="/app/shared/directives/custom-viewer-panel/custom-viewer-panel.css"/>" rel="stylesheet" />
+            <link href="<c:url value="/app/shared/directives/editable-map/editable-map.css"/>" rel="stylesheet" />
             <link href="<c:url value="/app/shared/changelog/changelog.css"/>" rel="stylesheet" />
             <link href="<c:url value="/app/shared/statistics/statistics.css"/>" rel="stylesheet" />
             <link href="<c:url value="/app/xconf/styles/rules.css"/>" rel="stylesheet" />

--- a/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.css
+++ b/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.css
@@ -1,0 +1,18 @@
+.edit-form {
+    margin-bottom: 3px;
+}
+.key-input {
+    width: 200px;
+}
+
+.value-input {
+    width: 483px;
+}
+
+.remove-parameter {
+    padding-top: 5px
+}
+
+.no-parameters {
+    margin-bottom: 0;
+}

--- a/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.css
+++ b/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.css
@@ -1,12 +1,12 @@
 .edit-form {
-    margin-bottom: 3px;
+    margin-bottom: 3px !important;
 }
 .key-input {
-    width: 200px;
+    width: 200px !important;
 }
 
 .value-input {
-    width: 483px;
+    width: 483px !important;
 }
 
 .remove-parameter {

--- a/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.css
+++ b/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.css
@@ -12,7 +12,3 @@
 .remove-parameter {
     padding-top: 5px
 }
-
-.no-parameters {
-    margin-bottom: 0;
-}

--- a/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.html
+++ b/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.html
@@ -36,7 +36,7 @@
     </div>
 
     <div class="btn-group">
-        <button id="addParameter" type="button" class="btn btn-success" ng-click="addParameterEntry()">
+        <button id="addParameter" type="button" class="btn btn-success" ng-click="addParameterEntry()" ng-disabled="parameters.length === maxNumberOfItems">
             <i class="ri-add-fill ri-sm"></i>
         </button>
         <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-expanded="false" ng-if="quickAdd.length > 0">

--- a/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.html
+++ b/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.html
@@ -19,21 +19,24 @@
 *
 -->
 <div class="editable-map-container">
-    <div class="form-inline" ng-repeat="property in parameters track by $id(property)">
-        <button type="button" class="btn btn-warning" ng-disabled="parameters.length === 1" ng-click="removeParameterEntry(property)">
+    <div class="alert alert-info" ng-if="parameters.length === 0" style="margin-bottom: 0">
+        <span>There are no parameters. Press "+" to add new parameter.</span>
+    </div>
+    <div class="form-inline" ng-repeat="property in parameters track by $id(property)" style="margin-bottom: 3px">
+        <button type="button" class="btn btn-warning" ng-click="removeParameterEntry(property)" style="padding-top: 5px">
             <i class=ri-delete-bin-7-line></i>
         </button>
         <div class="form-group" id="parameterEntries">
             <input type="text" class="form-control" ng-model="property.key"
                    uib-typeahead="autoValue for autoValue in autoCompleteValues"
                    typeahead-min-length="0"
-                   placeholder="Key"/>
-            <input type="text" class="form-control" ng-model="property.value" placeholder="Value"/>
+                   placeholder="Key"
+            style="width: 200px"/>
+            <input type="text" class="form-control" ng-model="property.value" placeholder="Value" style="width: 483px"/>
         </div>
     </div>
 
-    <!-- Buttons -->
-    <div class="btn-group" style="margin-top: 1em">
+    <div class="btn-group">
         <button id="addParameter" type="button" class="btn btn-success" ng-click="addParameterEntry()">
             <i class="ri-add-fill ri-sm"></i>
         </button>

--- a/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.html
+++ b/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.html
@@ -19,11 +19,10 @@
 *
 -->
 <div class="editable-map-container">
-    <div class="alert alert-info no-parameters" ng-if="parameters.length === 0">
-        <span>There are no parameters. Press "+" to add new parameter.</span>
-    </div>
     <div class="form-inline edit-form" ng-repeat="property in parameters track by $id(property)">
-        <button type="button" class="btn btn-warning remove-parameter" ng-click="removeParameterEntry(property)">
+        <button type="button" class="btn btn-warning remove-parameter"
+                ng-disabled="parameters.length === 1"
+                ng-click="removeParameterEntry(property)">
             <i class=ri-delete-bin-7-line></i>
         </button>
         <div class="form-group" id="parameterEntries">

--- a/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.html
+++ b/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.html
@@ -19,20 +19,20 @@
 *
 -->
 <div class="editable-map-container">
-    <div class="alert alert-info" ng-if="parameters.length === 0" style="margin-bottom: 0">
+    <div class="alert alert-info no-parameters" ng-if="parameters.length === 0">
         <span>There are no parameters. Press "+" to add new parameter.</span>
     </div>
-    <div class="form-inline" ng-repeat="property in parameters track by $id(property)" style="margin-bottom: 3px">
-        <button type="button" class="btn btn-warning" ng-click="removeParameterEntry(property)" style="padding-top: 5px">
+    <div class="form-inline edit-form" ng-repeat="property in parameters track by $id(property)">
+        <button type="button" class="btn btn-warning remove-parameter" ng-click="removeParameterEntry(property)">
             <i class=ri-delete-bin-7-line></i>
         </button>
         <div class="form-group" id="parameterEntries">
-            <input type="text" class="form-control" ng-model="property.key"
+            <input type="text" class="form-control key-input" ng-model="property.key"
                    uib-typeahead="autoValue for autoValue in autoCompleteValues"
                    typeahead-min-length="0"
                    placeholder="Key"
-            style="width: 200px"/>
-            <input type="text" class="form-control" ng-model="property.value" placeholder="Value" style="width: 483px"/>
+            />
+            <input type="text" class="form-control value-input" ng-model="property.value" placeholder="Value"/>
         </div>
     </div>
 

--- a/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.js
+++ b/xconf-angular-admin/src/main/webapp/app/shared/directives/editable-map/editable-map.directive.js
@@ -29,7 +29,8 @@
                 scope: {
                     parameters: '=',
                     autoCompleteValues: '=',
-                    quickAdd: '='
+                    quickAdd: '=',
+                    maxNumberOfItems: '='
                 },
                 templateUrl: 'app/shared/directives/editable-map/editable-map.directive.html',
                 link: function(scope) {

--- a/xconf-angular-admin/src/main/webapp/app/shared/pages/testpage/testpage.html
+++ b/xconf-angular-admin/src/main/webapp/app/shared/pages/testpage/testpage.html
@@ -21,8 +21,11 @@
 <div class="container">
     <h1 class="page-header">Test page</h1>
     <div class="row">
-        <div class="col-md-5">
+        <div class="col-md-12">
             <div class="form-group" style="font-size: 1.5em;">Parameters</div>
+            <div class="alert alert-info">
+                <span>Enter context parameters like estbMacAddress or env/model. Hit 'Test with parameters' button to see results.</span>
+            </div>
             <div class="form-group">
                 <editable-map parameters="vm.parameters"
                               auto-complete-values="vm.autoCompleteValues"></editable-map>
@@ -39,21 +42,15 @@
                     </dropdown-multiselect>
                 </div>
             </div>
-            <br />
-            <div style="padding-top: 1em;">
+            <div>
                 <button id="testButton" type="button" class="btn btn-primary"
                         ng-disabled=""
                         ng-click="vm.matchRule()">Test With Parameters</button>
             </div>
         </div>
-        <div class="col-md-7" ng-if="!vm.context">
-            <div class="form-group test-setting-heading">Tips</div>
-            <div class="alert alert-info">
-            <span>Enter context parameters like estbMacAddress or env/model. Hit 'Test with parameters' button to see results.
-            </span>
-            </div>
-        </div>
-        <div class="col-md-7">
+    </div>
+    <div class="row">
+        <div class="col-md-12" style="margin-top: 12px">
             <div ng-if="vm.context">
                 <div class="form-group test-setting-heading">Context</div>
                 <div class="alert alert-info break-word">

--- a/xconf-angular-admin/src/main/webapp/app/xconf/dcm/testpage/testpage.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/dcm/testpage/testpage.html
@@ -21,7 +21,10 @@
 <h1 class="page-header">Test page</h1>
 <div id="dcmTestPage">
     <div class="row">
-        <div class="col-md-5">
+        <div class="col-md-12">
+            <div class="alert alert-info">
+                <span>Enter context parameters like estbMacAddress or env/model. Hit 'Test with parameters' button to see results.</span>
+            </div>
             <div class="form-group" style="font-size: 1.5em;">Parameters</div>
             <editable-map parameters="vm.parameters"
                           auto-complete-values="vm.autoCompleteValues"></editable-map>
@@ -29,16 +32,11 @@
                 <button id="testButton" type="button" class="btn btn-primary"
                         ng-disabled=""
                         ng-click="vm.matchRule()">Test With Parameters</button>
-            </div>
         </div>
-        <div class="col-md-7" ng-if="!vm.context">
-            <div class="form-group" style="font-size: 1.5em;">Tips</div>
-            <div class="alert alert-info">
-            <span>Enter context parameters like estbMacAddress or env/model. Hit 'Test with parameters' button to see results.
-            </span>
-            </div>
         </div>
-        <div class="col-md-7">
+    </div>
+    <div class="row">
+        <div class="col-md-12" style="margin-top: 10px">
             <div ng-if="vm.context">
                 <div class="form-group" style="font-size: 1.5em;">Context</div>
                 <div class="alert alert-info break-word">
@@ -154,5 +152,6 @@
                 </table>
             </div>
         </div>
+    </div>
     </div>
 </div>

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.controller.js
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.controller.js
@@ -43,7 +43,7 @@
             supportedModelIds: [],
             applicationType: $rootScope.applicationType
         };
-        vm.parameters = [{key: '', value: ''}];
+        vm.properties = [{key: '', value: ''}];
         vm.PERMISSION = PERMISSION;
 
         vm.save = save;
@@ -83,10 +83,10 @@
                             }
                         }
                     });
-                    vm.parameters = [];
-                    vm.firmwareConfig.parameters = resp.data.parameters;
-                    for (var key in vm.firmwareConfig.parameters) {
-                        vm.parameters.push({key: key, value: vm.firmwareConfig.parameters[key]});
+                    vm.properties = [];
+                    vm.firmwareConfig.properties = resp.data.properties;
+                    for (var key in vm.firmwareConfig.properties) {
+                        vm.properties.push({key: key, value: vm.firmwareConfig.properties[key]});
                     }
                 }, function(error) {
                     alertsService.showError({title: 'Error', message: 'Error by loading FirmwareConfig'});
@@ -106,8 +106,8 @@
         }
 
         function save() {
-            if (validateFirmwareConfig(vm.firmwareConfig) && validateParameters(vm.parameters)) {
-                vm.firmwareConfig.parameters = keyValueObjectToMap(vm.parameters);
+            if (validateFirmwareConfig(vm.firmwareConfig) && validateProperties(vm.properties)) {
+                vm.firmwareConfig.properties = keyValueObjectToMap(vm.properties);
 
                 if (vm.firmwareConfig.id) {
                     firmwareConfigService.update(vm.firmwareConfig).then(function (resp) {
@@ -127,9 +127,9 @@
             }
         }
 
-        function keyValueObjectToMap(parameters) {
+        function keyValueObjectToMap(properties) {
             let mapObject = {};
-            parameters.forEach(function (item) {
+            properties.forEach(function (item) {
                 if (item.key) {
                     mapObject[item.key] = item.value;
                 }
@@ -159,13 +159,13 @@
             return true;
         }
 
-        function validateParameters(parameters) {
-            if (!validateParameterKeyUniqueness(parameters)) {
+        function validateProperties(properties) {
+            if (!validatePropertyKeyUniqueness(properties)) {
                 alertsService.showError({title: 'Error', message: 'Keys are not unique'});
                 return false;
             }
 
-            if (!validateKeysAreNotEmpty(parameters)) {
+            if (!validateKeysAreNotEmpty(properties)) {
                 alertsService.showError({title: 'Error', message: 'Key is empty'});
                 return false;
             }
@@ -173,14 +173,14 @@
             return true;
         }
 
-        function validateParameterKeyUniqueness(parameters) {
-            let keys = _.map(parameters, function(entry) {return entry.key});
+        function validatePropertyKeyUniqueness(properties) {
+            let keys = _.map(properties, function(entry) {return entry.key});
             let uniqKeys = _.uniq(keys);
             return keys.length === uniqKeys.length;
         }
 
-        function validateKeysAreNotEmpty(parameters) {
-            let emptyIndex = _.findIndex(parameters, function(entry) {return utilsService.isEmptyString(entry.key)});
+        function validateKeysAreNotEmpty(properties) {
+            let emptyIndex = _.findIndex(properties, function(entry) {return utilsService.isEmptyString(entry.key)});
             return emptyIndex === -1;
         }
     }

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.controller.js
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.controller.js
@@ -165,11 +165,6 @@
                 return false;
             }
 
-            if (!validateKeysAreNotEmpty(properties)) {
-                alertsService.showError({title: 'Error', message: 'Key is empty'});
-                return false;
-            }
-
             return true;
         }
 
@@ -177,11 +172,6 @@
             let keys = _.map(properties, function(entry) {return entry.key});
             let uniqKeys = _.uniq(keys);
             return keys.length === uniqKeys.length;
-        }
-
-        function validateKeysAreNotEmpty(properties) {
-            let emptyIndex = _.findIndex(properties, function(entry) {return utilsService.isEmptyString(entry.key)});
-            return emptyIndex === -1;
         }
     }
 

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.html
@@ -56,8 +56,8 @@
     <div class="col-md-10">
         <div class="form-group">
             <div>
-                <label>Parameters:</label>
-                <editable-map parameters="vm.parameters"></editable-map>
+                <label>Properties:</label>
+                <editable-map parameters="vm.properties"></editable-map>
             </div>
         </div>
     </div>

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.html
@@ -57,7 +57,7 @@
         <div class="form-group">
             <div>
                 <label>Properties:</label>
-                <editable-map parameters="vm.properties"></editable-map>
+                <editable-map parameters="vm.properties" max-number-of-items="20"></editable-map>
             </div>
         </div>
     </div>

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-edit.html
@@ -19,38 +19,54 @@
 *
 -->
 <h1 class="page-header">Firmware config</h1>
-<div class="col-md-8">
-    <div class="input-group">
-        <span class="input-group-addon">Description</span>
-        <input title="Description" class="form-control" ng-model="vm.firmwareConfig.description" type="text"/>
-    </div>
-    <br>
-    <div class="input-group">
-        <span class="input-group-addon">File name</span>
-        <input title="File name" class="form-control" ng-model="vm.firmwareConfig.firmwareFilename" type="text">
-    </div>
-    <br>
-    <div class="input-group">
-        <span class="input-group-addon">Version</span>
-        <input title="Version" class="form-control" type="text" ng-model="vm.firmwareConfig.firmwareVersion"/>
-    </div>
-    <br>
-    <div class="form-group">
-        <label>Models:</label>
-        <div class="row">
-            <div class="col-md-12">
-                <ul id="supportedModelList" class="xconf-list">
-                    <li class="ads-list-item ads-list-item-horizontal xconf-list-item xconf-list-item-grey edit-list"
-                        ng-repeat="val in vm.models"
-                        ng-class="{'checked-in-list': val.selected}"
-                        ng-bind="val.modelId"
-                        ng-click="vm.selectModel(val)"></li>
-                </ul>
+<div class="row">
+    <div class="col-md-8">
+        <div class="input-group">
+            <span class="input-group-addon">Description</span>
+            <input title="Description" class="form-control" ng-model="vm.firmwareConfig.description" type="text"/>
+        </div>
+        <br>
+        <div class="input-group">
+            <span class="input-group-addon">File name</span>
+            <input title="File name" class="form-control" ng-model="vm.firmwareConfig.firmwareFilename" type="text">
+        </div>
+        <br>
+        <div class="input-group">
+            <span class="input-group-addon">Version</span>
+            <input title="Version" class="form-control" type="text" ng-model="vm.firmwareConfig.firmwareVersion"/>
+        </div>
+        <br>
+        <div class="form-group">
+            <label>Models:</label>
+            <div class="row">
+                <div class="col-md-12">
+                    <ul id="supportedModelList" class="xconf-list">
+                        <li class="ads-list-item ads-list-item-horizontal xconf-list-item xconf-list-item-grey edit-list"
+                            ng-repeat="val in vm.models"
+                            ng-class="{'checked-in-list': val.selected}"
+                            ng-bind="val.modelId"
+                            ng-click="vm.selectModel(val)"></li>
+                    </ul>
+                </div>
             </div>
         </div>
     </div>
-    <div>
-        <button type="button" class="btn btn-success" ng-click="vm.save()" title="Save">Save</button>
-        <button type="button" class="btn btn-default" ui-sref="firmwareconfigs">Cancel</button>
+</div>
+<div class="row">
+    <div class="col-md-10">
+        <div class="form-group">
+            <div>
+                <label>Parameters:</label>
+                <editable-map parameters="vm.parameters"></editable-map>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-10">
+        <div class="form-group">
+            <button type="button" class="btn btn-success" ng-click="vm.save()" title="Save">Save</button>
+            <button type="button" class="btn btn-default" ui-sref="firmwareconfigs">Cancel</button>
+        </div>
     </div>
 </div>

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.controller.js
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.controller.js
@@ -30,13 +30,13 @@
         vm.firmwareConfig = firmwareConfig;
 
         vm.dismiss = dismiss;
-        vm.parametersAreNotEmpty = parametersAreNotEmpty;
+        vm.propertiesAreNotEmpty = propertiesAreNotEmpty;
 
         function dismiss() {
             $modalInstance.dismiss();
         }
 
-        function parametersAreNotEmpty(parameters) {
+        function propertiesAreNotEmpty(parameters) {
             return !utilsService.isMapEmpty(parameters);
         }
     }

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.controller.js
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.controller.js
@@ -23,14 +23,21 @@
         .module('app.firmwareconfig')
         .controller('FirmwareConfigViewController', controller);
 
-    controller.$inject = ['$uibModalInstance', 'firmwareConfig'];
+    controller.$inject = ['$uibModalInstance', 'firmwareConfig', 'utilsService'];
 
-    function controller($modalInstance, firmwareConfig) {
+    function controller($modalInstance, firmwareConfig, utilsService) {
         var vm = this;
-        vm.dismiss = dismiss;
         vm.firmwareConfig = firmwareConfig;
+
+        vm.dismiss = dismiss;
+        vm.parametersAreNotEmpty = parametersAreNotEmpty;
+
         function dismiss() {
             $modalInstance.dismiss();
+        }
+
+        function parametersAreNotEmpty(parameters) {
+            return !utilsService.isMapEmpty(parameters);
         }
     }
 })();

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.html
@@ -48,7 +48,7 @@
     </ul>
 
     <div ng-if="vm.propertiesAreNotEmpty(vm.firmwareConfig.properties)">
-        <label for="version">Properties:</label>
+        <label>Properties:</label>
         <table class="table table-striped">
             <colgroup width="200"/>
             <colgroup />

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.html
@@ -46,4 +46,16 @@
             ng-repeat="modelId in vm.firmwareConfig.supportedModelIds"
             ng-bind="modelId"></li>
     </ul>
+
+    <div ng-if="vm.parametersAreNotEmpty(vm.firmwareConfig.parameters)">
+        <label for="version">Parameters:</label>
+        <table class="table table-striped">
+            <colgroup width="200"/>
+            <colgroup />
+            <tr ng-repeat="(key, value) in vm.firmwareConfig.parameters">
+                <td ng-bind="key"></td>
+                <td ng-bind="value"></td>
+            </tr>
+        </table>
+    </div>
 </div>

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/firmwareconfig/firmwareconfig-view.html
@@ -47,12 +47,12 @@
             ng-bind="modelId"></li>
     </ul>
 
-    <div ng-if="vm.parametersAreNotEmpty(vm.firmwareConfig.parameters)">
-        <label for="version">Parameters:</label>
+    <div ng-if="vm.propertiesAreNotEmpty(vm.firmwareConfig.properties)">
+        <label for="version">Properties:</label>
         <table class="table table-striped">
             <colgroup width="200"/>
             <colgroup />
-            <tr ng-repeat="(key, value) in vm.firmwareConfig.parameters">
+            <tr ng-repeat="(key, value) in vm.firmwareConfig.properties">
                 <td ng-bind="key"></td>
                 <td ng-bind="value"></td>
             </tr>

--- a/xconf-angular-admin/src/main/webapp/app/xconf/firmware/testpage/testpage.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/firmware/testpage/testpage.html
@@ -20,25 +20,24 @@
 -->
 <h1 class="page-header">Firmware Test page</h1>
 <div id="firmwareRuleTestPage" class="row" style="margin-top: -10px">
-    <div class="col-md-5">
+    <div class="col-md-12">
         <div class="form-group" style="font-size: 1.5em;">Parameters</div>
-        <editable-map parameters="vm.parameters"
-                      auto-complete-values="vm.autoCompleteValues" quick-add="vm.quickAddValues"></editable-map>
-        <div style="padding-top: 1em;">
-            <button id="test" type="button" class="btn btn-primary"
-                    ng-click="vm.matchRules()">Test With Parameters</button>
-        </div>
-    </div>
-    <div class="col-md-7" ng-if="!vm.result">
-        <div class="form-group" style="font-size: 1.5em;">Tips</div>
         <div class="alert alert-info">
             <span>Enter context parameters like estbMac or env/model.
                 Use toggle near plus sign to add predefined capabilities (RCDL, rebootDecoupled, supportsFullHttpUrl).
                 Hit 'Test with parameters' button to see results.
             </span>
         </div>
+        <editable-map parameters="vm.parameters"
+                      auto-complete-values="vm.autoCompleteValues" quick-add="vm.quickAddValues"></editable-map>
+        <div class="form-group" style="margin-top: 10px">
+            <button id="test" type="button" class="btn btn-primary"
+                    ng-click="vm.matchRules()">Test With Parameters</button>
+        </div>
     </div>
-    <div class="col-md-7" ng-if="vm.result">
+</div>
+<div class="row">
+    <div class="col-md-12" ng-if="vm.result">
         <div ng-if="vm.context">
             <div class="form-group" style="font-size: 1.5em;">Context</div>
             <div class="alert alert-info break-word">

--- a/xconf-angular-admin/src/main/webapp/app/xconf/rfc/feature/feature-edit.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/rfc/feature/feature-edit.html
@@ -42,7 +42,7 @@
         <br/>
         <div class="form-group">
             <div>
-                <h4>Config Data:</h4>
+                <label>Config Data:</label>
                 <editable-map parameters="vm.parameters" auto-complete-values="vm.autoCompleteValues" quick-add="vm.quickAddValues"></editable-map>
             </div>
         </div>

--- a/xconf-angular-admin/src/main/webapp/app/xconf/telemetry/telemetrytwotestpage/telemetrytwotestpage.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/telemetry/telemetrytwotestpage/telemetrytwotestpage.html
@@ -21,8 +21,11 @@
 <div class="container">
     <h1 class="page-header">Telemetry 2.0 Test page</h1>
     <div class="row">
-        <div class="col-md-5">
+        <div class="col-md-12">
             <div class="form-group" style="font-size: 1.5em;">Parameters</div>
+            <div class="alert alert-info">
+                <span>Enter context parameters like estbMacAddress or env/model. Hit 'Test with parameters' button to see results.</span>
+            </div>
             <editable-map parameters="vm.parameters"
                           auto-complete-values="vm.autoCompleteValues"></editable-map>
             <div style="padding-top: 1em;">
@@ -31,14 +34,9 @@
                         ng-click="vm.matchRules()">Test With Parameters</button>
             </div>
         </div>
-        <div class="col-md-7" ng-if="!vm.context">
-            <div class="form-group" style="font-size: 1.5em;">Tips</div>
-            <div class="alert alert-info">
-            <span>Enter context parameters like estbMacAddress or env/model. Hit 'Test with parameters' button to see results.
-            </span>
-            </div>
-        </div>
-        <div class="col-md-7">
+    </div>
+    <div class="row" style="margin-top: 12px">
+        <div class="col-md-12">
             <div ng-if="vm.context">
                 <div class="form-group" style="font-size: 1.5em;">Context</div>
                 <div class="alert alert-info break-word">

--- a/xconf-angular-admin/src/main/webapp/app/xconf/telemetry/testpage/testpage.html
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/telemetry/testpage/testpage.html
@@ -21,8 +21,11 @@
 <div class="container">
     <h1 class="page-header">Test page</h1>
     <div class="row">
-        <div class="col-md-5">
+        <div class="col-md-12">
             <div class="form-group" style="font-size: 1.5em;">Parameters</div>
+            <div class="alert alert-info">
+                <span>Enter context parameters like estbMacAddress or env/model. Hit 'Test with parameters' button to see results.</span>
+            </div>
             <editable-map parameters="vm.parameters"
                           auto-complete-values="vm.autoCompleteValues"></editable-map>
             <div style="padding-top: 1em;">
@@ -31,14 +34,9 @@
                         ng-click="vm.matchRules()">Test With Parameters</button>
             </div>
         </div>
-        <div class="col-md-7" ng-if="!vm.context">
-            <div class="form-group" style="font-size: 1.5em;">Tips</div>
-            <div class="alert alert-info">
-            <span>Enter context parameters like estbMacAddress or env/model. Hit 'Test with parameters' button to see results.
-            </span>
-            </div>
-        </div>
-        <div class="col-md-7">
+    </div>
+    <div class="row" style="margin-top: 12px">
+        <div class="col-md-12">
             <div ng-if="vm.context">
                 <div class="form-group" style="font-size: 1.5em;">Context</div>
                 <div class="alert alert-info break-word">

--- a/xconf-angular-admin/src/main/webapp/package.json
+++ b/xconf-angular-admin/src/main/webapp/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "bower": "^1.8.12",
     "cli": "^1.0.1",
-    "grunt-cli": "^1.4.2"
+    "grunt-cli": "^1.4.3"
   },
   "devDependencies": {
     "grunt": "~0.4.5",

--- a/xconf-angular-admin/src/test/java/com/comcast/xconf/admin/controller/firmware/FirmwareConfigControllerTest.java
+++ b/xconf-angular-admin/src/test/java/com/comcast/xconf/admin/controller/firmware/FirmwareConfigControllerTest.java
@@ -302,17 +302,17 @@ public class FirmwareConfigControllerTest extends BaseControllerTest {
     @Test
     public void getFirmwareConfigWithParameters() throws Exception {
         Model model = createAndSaveModel(defaultModelId.toUpperCase());
-        Map<String, String> parameters = Collections.singletonMap("testKey", "testValue");
+        Map<String, String> properties = Collections.singletonMap("testKey", "testValue");
 
         FirmwareConfig firmwareConfig = createFirmwareConfig();
-        firmwareConfig.setParameters(parameters);
+        firmwareConfig.setProperties(properties);
         saveFirmwareConfig(firmwareConfig);
 
         nullifyUnwantedFields(firmwareConfig);
 
         mockMvc.perform(get("/" + FirmwareConfigController.URL_MAPPING + "/" + firmwareConfig.getId())
                 .accept(MediaType.APPLICATION_JSON)).andExpect(content().json(JsonUtil.toJson(firmwareConfig)))
-                .andExpect(jsonPath("$.parameters.testKey").value("testValue"))
+                .andExpect(jsonPath("$.properties.testKey").value("testValue"))
                 .andExpect(status().isOk());
     }
 
@@ -320,14 +320,14 @@ public class FirmwareConfigControllerTest extends BaseControllerTest {
     public void createFirmwareConfigWithParameters() throws Exception {
         Model model = createAndSaveModel(defaultModelId.toUpperCase());
         FirmwareConfig firmwareConfig = createFirmwareConfig();
-        firmwareConfig.setParameters(Collections.singletonMap("testKey", "testValue"));
+        firmwareConfig.setProperties(Collections.singletonMap("testKey", "testValue"));
 
         mockMvc.perform(post("/" + FirmwareConfigController.URL_MAPPING)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(JsonUtil.toJson(firmwareConfig)))
                 .andExpect(status().isCreated());
 
-        assertEquals(firmwareConfig.getParameters(), firmwareConfigDAO.getOne(firmwareConfig.getId()).getParameters());
+        assertEquals(firmwareConfig.getProperties(), firmwareConfigDAO.getOne(firmwareConfig.getId()).getProperties());
     }
 
     @Test
@@ -336,19 +336,19 @@ public class FirmwareConfigControllerTest extends BaseControllerTest {
         FirmwareConfig firmwareConfig = createFirmwareConfig();
         saveFirmwareConfig(firmwareConfig);
 
-        assertTrue(MapUtils.isEmpty(firmwareConfigDAO.getOne(firmwareConfig.getId()).getParameters()));
+        assertTrue(MapUtils.isEmpty(firmwareConfigDAO.getOne(firmwareConfig.getId()).getProperties()));
 
         Map<String, String> parameters = Collections.singletonMap("testKey", "testValue");
 
         FirmwareConfig firmwareConfigToUpdate = new FirmwareConfig(firmwareConfig);
-        firmwareConfigToUpdate.setParameters(parameters);
+        firmwareConfigToUpdate.setProperties(parameters);
 
         mockMvc.perform(put("/" + FirmwareConfigController.URL_MAPPING)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtil.toJson(firmwareConfigToUpdate)))
                 .andExpect(status().isOk());
 
-        assertEquals(parameters, firmwareConfigDAO.getOne(firmwareConfigToUpdate.getId()).getParameters());
+        assertEquals(parameters, firmwareConfigDAO.getOne(firmwareConfigToUpdate.getId()).getProperties());
     }
 
     @Test
@@ -357,27 +357,27 @@ public class FirmwareConfigControllerTest extends BaseControllerTest {
         Map<String, String> parameters = Collections.singletonMap("testKey", "testValue");
 
         FirmwareConfig firmwareConfig = createFirmwareConfig();
-        firmwareConfig.setParameters(parameters);
+        firmwareConfig.setProperties(parameters);
         saveFirmwareConfig(firmwareConfig);
 
-        assertEquals(parameters, firmwareConfigDAO.getOne(firmwareConfig.getId()).getParameters());
+        assertEquals(parameters, firmwareConfigDAO.getOne(firmwareConfig.getId()).getProperties());
 
         FirmwareConfig firmwareConfigToUpdate = new FirmwareConfig(firmwareConfig);
-        firmwareConfigToUpdate.setParameters(new HashMap<>());
+        firmwareConfigToUpdate.setProperties(new HashMap<>());
 
         mockMvc.perform(put("/" + FirmwareConfigController.URL_MAPPING)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtil.toJson(firmwareConfigToUpdate)))
                 .andExpect(status().isOk());
 
-        assertTrue(MapUtils.isEmpty(firmwareConfigDAO.getOne(firmwareConfigToUpdate.getId()).getParameters()));
+        assertTrue(MapUtils.isEmpty(firmwareConfigDAO.getOne(firmwareConfigToUpdate.getId()).getProperties()));
     }
 
     @Test
     public void createFirmwareConfigWithEmptyKeyParameter() throws Exception {
         Model model = createAndSaveModel(defaultModelId.toUpperCase());
         FirmwareConfig firmwareConfig = createFirmwareConfig();
-        firmwareConfig.setParameters(Collections.singletonMap("", "testValue"));
+        firmwareConfig.setProperties(Collections.singletonMap("", "testValue"));
 
         mockMvc.perform(post("/" + FirmwareConfigController.URL_MAPPING)
                 .contentType(MediaType.APPLICATION_JSON)

--- a/xconf-automation-tests/pom.xml
+++ b/xconf-automation-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-automation-tests/pom.xml
+++ b/xconf-automation-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-automation-tests/pom.xml
+++ b/xconf-automation-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-automation-tests/pom.xml
+++ b/xconf-automation-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-automation-tests/pom.xml
+++ b/xconf-automation-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-automation-tests/pom.xml
+++ b/xconf-automation-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-automation-tests/pom.xml
+++ b/xconf-automation-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-automation-tests/pom.xml
+++ b/xconf-automation-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.2.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-common/pom.xml
+++ b/xconf-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-common/pom.xml
+++ b/xconf-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-common/pom.xml
+++ b/xconf-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3-SNAPSHOT</version>
+        <version>1.3.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-common/pom.xml
+++ b/xconf-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-common/pom.xml
+++ b/xconf-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-common/pom.xml
+++ b/xconf-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-common/pom.xml
+++ b/xconf-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-common/pom.xml
+++ b/xconf-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.comcast.coast.xconf.oss</groupId>
         <artifactId>xconf</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.2.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfig.java
+++ b/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfig.java
@@ -77,7 +77,7 @@ public class FirmwareConfig extends XMLPersistable implements Comparable<Firmwar
 
     private String applicationType = ApplicationType.STB;
 
-    private Map<String, String> parameters = new HashMap<>();
+    private Map<String, String> properties = new HashMap<>();
 
     public FirmwareConfig() {
     }
@@ -97,7 +97,7 @@ public class FirmwareConfig extends XMLPersistable implements Comparable<Firmwar
         upgradeDelay = c.upgradeDelay;
         rebootImmediately = c.rebootImmediately;
         setSupportedModelIds(new HashSet<String>(c.supportedModelIds));
-        parameters = c.getParameters();
+        properties = c.getProperties();
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -186,12 +186,12 @@ public class FirmwareConfig extends XMLPersistable implements Comparable<Firmwar
         this.applicationType = applicationType;
     }
 
-    public Map<String, String> getParameters() {
-        return parameters;
+    public Map<String, String> getProperties() {
+        return properties;
     }
 
-    public void setParameters(Map<String, String> parameters) {
-        this.parameters = parameters;
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
     }
 
     @Override

--- a/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfig.java
+++ b/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfig.java
@@ -186,6 +186,7 @@ public class FirmwareConfig extends XMLPersistable implements Comparable<Firmwar
         this.applicationType = applicationType;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getProperties() {
         return properties;
     }

--- a/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfig.java
+++ b/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfig.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * If not stated otherwise in this file or this component's Licenses.txt file the 
  * following copyright and licenses apply:
  *
@@ -36,9 +36,7 @@ import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Firmware configuration for eSTBs.
@@ -79,6 +77,8 @@ public class FirmwareConfig extends XMLPersistable implements Comparable<Firmwar
 
     private String applicationType = ApplicationType.STB;
 
+    private Map<String, String> parameters = new HashMap<>();
+
     public FirmwareConfig() {
     }
 
@@ -97,6 +97,7 @@ public class FirmwareConfig extends XMLPersistable implements Comparable<Firmwar
         upgradeDelay = c.upgradeDelay;
         rebootImmediately = c.rebootImmediately;
         setSupportedModelIds(new HashSet<String>(c.supportedModelIds));
+        parameters = c.getParameters();
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -183,6 +184,14 @@ public class FirmwareConfig extends XMLPersistable implements Comparable<Firmwar
     @Override
     public void setApplicationType(String applicationType) {
         this.applicationType = applicationType;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
     }
 
     @Override

--- a/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfigFacade.java
+++ b/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfigFacade.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 
@@ -60,12 +61,19 @@ public class FirmwareConfigFacade {
         putIfPresent(map, ConfigNames.IPV6_FIRMWARE_LOCATION, firmwareConfig.getIpv6FirmwareLocation());
         putIfPresent(map, ConfigNames.UPGRADE_DELAY, firmwareConfig.getUpgradeDelay());
         putIfPresent(map, ConfigNames.REBOOT_IMMEDIATELY, firmwareConfig.getRebootImmediately());
+        putFirmwareConfigParameters(map, firmwareConfig.getParameters());
         properties = map;
     }
 
     public void putIfPresent(Map<String, Object> map, String key, Object value) {
         if (!isEmpty(value)) {
             map.put(key, value);
+        }
+    }
+
+    public void putFirmwareConfigParameters(Map<String, Object> properties, Map<String, String> configParameters) {
+        if (MapUtils.isNotEmpty(configParameters)) {
+            properties.putAll(configParameters);
         }
     }
 

--- a/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfigFacade.java
+++ b/xconf-common/src/main/java/com/comcast/xconf/estbfirmware/FirmwareConfigFacade.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -45,6 +46,7 @@ import java.util.Map;
 public class FirmwareConfigFacade {
 
     private Map<String, Object> properties = new LinkedHashMap<>();
+    private Map<String, String> customProperties = new HashMap<>();
 
     public FirmwareConfigFacade() {}
 
@@ -61,7 +63,7 @@ public class FirmwareConfigFacade {
         putIfPresent(map, ConfigNames.IPV6_FIRMWARE_LOCATION, firmwareConfig.getIpv6FirmwareLocation());
         putIfPresent(map, ConfigNames.UPGRADE_DELAY, firmwareConfig.getUpgradeDelay());
         putIfPresent(map, ConfigNames.REBOOT_IMMEDIATELY, firmwareConfig.getRebootImmediately());
-        putFirmwareConfigParameters(map, firmwareConfig.getParameters());
+        putCustomProperties(customProperties, firmwareConfig.getProperties());
         properties = map;
     }
 
@@ -71,9 +73,9 @@ public class FirmwareConfigFacade {
         }
     }
 
-    public void putFirmwareConfigParameters(Map<String, Object> properties, Map<String, String> configParameters) {
-        if (MapUtils.isNotEmpty(configParameters)) {
-            properties.putAll(configParameters);
+    public void putCustomProperties(Map<String, String> properties, Map<String, String> configProperties) {
+        if (MapUtils.isNotEmpty(configProperties)) {
+            properties.putAll(configProperties);
         }
     }
 
@@ -148,6 +150,9 @@ public class FirmwareConfigFacade {
         return flag != null && flag instanceof Boolean ? (Boolean) flag : false;
     }
 
+    public Map<String, String> getCustomProperties() {
+        return customProperties;
+    }
     /**
      * Will exclude from response fields, like id, description, supportedModelIds, updated.
      * And also empty values and blank strings.
@@ -188,6 +193,10 @@ public class FirmwareConfigFacade {
             if (!isRedundantEntry(entry)) {
                 map.put(entry.getKey(), entry.getValue());
             }
+        }
+
+        if (MapUtils.isNotEmpty(getCustomProperties())) {
+            map.putAll(getCustomProperties());
         }
 
         return new FirmwareConfigFacade(map);

--- a/xconf-dataservice/pom.xml
+++ b/xconf-dataservice/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.coast.xconf.oss</groupId>
 		<artifactId>xconf</artifactId>
-		<version>1.3.2</version>
+		<version>1.3.3-SNAPSHOT</version>
 	</parent>
 
 	<name>xconf-dataservice</name>

--- a/xconf-dataservice/pom.xml
+++ b/xconf-dataservice/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.coast.xconf.oss</groupId>
 		<artifactId>xconf</artifactId>
-		<version>1.3.1-SNAPSHOT</version>
+		<version>1.3.1</version>
 	</parent>
 
 	<name>xconf-dataservice</name>

--- a/xconf-dataservice/pom.xml
+++ b/xconf-dataservice/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.coast.xconf.oss</groupId>
 		<artifactId>xconf</artifactId>
-		<version>1.3.3</version>
+		<version>1.3.4-SNAPSHOT</version>
 	</parent>
 
 	<name>xconf-dataservice</name>

--- a/xconf-dataservice/pom.xml
+++ b/xconf-dataservice/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.coast.xconf.oss</groupId>
 		<artifactId>xconf</artifactId>
-		<version>1.2.3-SNAPSHOT</version>
+		<version>1.2.3</version>
 	</parent>
 
 	<name>xconf-dataservice</name>

--- a/xconf-dataservice/pom.xml
+++ b/xconf-dataservice/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.coast.xconf.oss</groupId>
 		<artifactId>xconf</artifactId>
-		<version>1.2.3</version>
+		<version>1.2.4-SNAPSHOT</version>
 	</parent>
 
 	<name>xconf-dataservice</name>

--- a/xconf-dataservice/pom.xml
+++ b/xconf-dataservice/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.coast.xconf.oss</groupId>
 		<artifactId>xconf</artifactId>
-		<version>1.3.1</version>
+		<version>1.3.2-SNAPSHOT</version>
 	</parent>
 
 	<name>xconf-dataservice</name>

--- a/xconf-dataservice/pom.xml
+++ b/xconf-dataservice/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.coast.xconf.oss</groupId>
 		<artifactId>xconf</artifactId>
-		<version>1.3.3-SNAPSHOT</version>
+		<version>1.3.3</version>
 	</parent>
 
 	<name>xconf-dataservice</name>

--- a/xconf-dataservice/pom.xml
+++ b/xconf-dataservice/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.coast.xconf.oss</groupId>
 		<artifactId>xconf</artifactId>
-		<version>1.3.2-SNAPSHOT</version>
+		<version>1.3.2</version>
 	</parent>
 
 	<name>xconf-dataservice</name>

--- a/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesController.java
+++ b/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesController.java
@@ -208,9 +208,12 @@ public class FirmwareConfigQueriesController extends BaseQueriesController {
 
         Map<String, String> properties = firmwareConfig.getProperties();
         if (MapUtils.isNotEmpty(properties)) {
-            for (Map.Entry<String, String> parameter : firmwareConfig.getProperties().entrySet()) {
-                if (StringUtils.isBlank(parameter.getKey())) {
+            for (Map.Entry<String, String> property : firmwareConfig.getProperties().entrySet()) {
+                if (StringUtils.isBlank(property.getKey())) {
                     throw new ValidationRuntimeException("Key is empty");
+                }
+                if (StringUtils.isBlank(property.getValue())) {
+                    throw new ValidationRuntimeException("Value is blank for key: " + property.getKey());
                 }
             }
         }

--- a/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesController.java
+++ b/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesController.java
@@ -203,8 +203,8 @@ public class FirmwareConfigQueriesController extends BaseQueriesController {
             }
         }
 
-        if (MapUtils.isNotEmpty(firmwareConfig.getParameters())) {
-            for (Map.Entry<String, String> parameter : firmwareConfig.getParameters().entrySet()) {
+        if (MapUtils.isNotEmpty(firmwareConfig.getProperties())) {
+            for (Map.Entry<String, String> parameter : firmwareConfig.getProperties().entrySet()) {
                 if (StringUtils.isBlank(parameter.getKey())) {
                     throw new ValidationRuntimeException("Key is empty");
                 }

--- a/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesController.java
+++ b/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesController.java
@@ -45,6 +45,9 @@ import java.util.stream.Collectors;
 @RestController
 public class FirmwareConfigQueriesController extends BaseQueriesController {
 
+    public static final String MAX_ALLOWED_NUMBER_OF_PROPERTIES_ERR_MSG_TEMPLATE = "Max allowed number of properties is %s";
+    public static final int MAX_ALLOWED_NUMBER_OF_PROPERTIES = 20;
+
     @Autowired
     private CachedSimpleDao<String, FirmwareConfig> firmwareConfigDAO;
 
@@ -203,12 +206,17 @@ public class FirmwareConfigQueriesController extends BaseQueriesController {
             }
         }
 
-        if (MapUtils.isNotEmpty(firmwareConfig.getProperties())) {
+        Map<String, String> properties = firmwareConfig.getProperties();
+        if (MapUtils.isNotEmpty(properties)) {
             for (Map.Entry<String, String> parameter : firmwareConfig.getProperties().entrySet()) {
                 if (StringUtils.isBlank(parameter.getKey())) {
                     throw new ValidationRuntimeException("Key is empty");
                 }
             }
+        }
+
+        if (MapUtils.isNotEmpty(properties) && properties.size() > MAX_ALLOWED_NUMBER_OF_PROPERTIES) {
+            throw new ValidationRuntimeException(String.format(MAX_ALLOWED_NUMBER_OF_PROPERTIES_ERR_MSG_TEMPLATE, MAX_ALLOWED_NUMBER_OF_PROPERTIES));
         }
 
         return null;

--- a/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesController.java
+++ b/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesController.java
@@ -19,6 +19,7 @@
 package com.comcast.xconf.queries.controllers;
 
 import com.comcast.apps.dataaccess.cache.dao.CachedSimpleDao;
+import com.comcast.apps.dataaccess.support.exception.ValidationRuntimeException;
 import com.comcast.xconf.ApiVersionUtils;
 import com.comcast.xconf.estbfirmware.FirmwareConfig;
 import com.comcast.xconf.estbfirmware.FirmwareConfigQueriesService;
@@ -28,6 +29,7 @@ import com.comcast.xconf.queries.QueriesHelper;
 import com.comcast.xconf.queries.QueryConstants;
 import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,10 +39,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RestController
@@ -203,7 +202,15 @@ public class FirmwareConfigQueriesController extends BaseQueriesController {
                 return "Model: " + modelId + " is not exist";
             }
         }
+
+        if (MapUtils.isNotEmpty(firmwareConfig.getParameters())) {
+            for (Map.Entry<String, String> parameter : firmwareConfig.getParameters().entrySet()) {
+                if (StringUtils.isBlank(parameter.getKey())) {
+                    throw new ValidationRuntimeException("Key is empty");
+                }
+            }
+        }
+
         return null;
     }
-
 }

--- a/xconf-dataservice/src/test/java/com/comcast/xconf/estbfirmware/EstbFirmwareControllerTest.java
+++ b/xconf-dataservice/src/test/java/com/comcast/xconf/estbfirmware/EstbFirmwareControllerTest.java
@@ -1340,6 +1340,28 @@ public class EstbFirmwareControllerTest extends BaseQueriesControllerTest {
                 .andExpect(status().isOk()).andExpect(jsonPath("$.firmwareVersion").value(lkgConfig.getFirmwareVersion()));
     }
 
+    @Test
+    public void firmwareConfigsParametersAreReturned() throws Exception {
+        Map<String, String> parameters = new HashMap<>();
+        String configKey = "bindingUrl";
+        String configValue = "http://test.url.com";
+        parameters.put(configKey, configValue);
+
+        FirmwareConfig firmwareConfig = createFirmwareConfig(defaultFirmwareVersion, defaultModelId, FirmwareConfig.DownloadProtocol.http);
+        firmwareConfig.setParameters(parameters);
+        firmwareConfigDAO.setOne(firmwareConfig.getId(), firmwareConfig);
+
+        createAndSaveUseAccountPercentageBean(firmwareConfig);
+
+        EstbFirmwareContext context = createDefaultContext();
+        context.setFirmwareVersion(defaultFirmwareVersion);
+
+        mockMvc.perform(postContext("/xconf/swu/stb", context))
+                .andExpect(status().isOk()).
+                andExpect(jsonPath("$.firmwareVersion").value(firmwareConfig.getFirmwareVersion()))
+                .andExpect(jsonPath("$.bindingUrl").value(configValue));
+    }
+
     private PercentageBean createAndSaveUseAccountPercentageBean(FirmwareConfig lkgConfig) {
         PercentageBean useAccountBean = createPercentageBean("useAccountName", defaultEnvironmentId, defaultModelId, null, null, defaultFirmwareVersion, STB);
         useAccountBean.setUseAccountIdPercentage(true);
@@ -1460,6 +1482,7 @@ public class EstbFirmwareControllerTest extends BaseQueriesControllerTest {
         config.setId(null);
         config.setDescription(null);
         config.setSupportedModelIds(null);
+        config.setParameters(null);
         config.setUpdated(null);
         config.setApplicationType(null);
     }

--- a/xconf-dataservice/src/test/java/com/comcast/xconf/estbfirmware/EstbFirmwareControllerTest.java
+++ b/xconf-dataservice/src/test/java/com/comcast/xconf/estbfirmware/EstbFirmwareControllerTest.java
@@ -38,10 +38,7 @@ import com.comcast.xconf.estbfirmware.converter.TimeFilterConverter;
 import com.comcast.xconf.estbfirmware.factory.RuleFactory;
 import com.comcast.xconf.estbfirmware.factory.TemplateFactory;
 import com.comcast.xconf.estbfirmware.util.LogsCompatibilityUtils;
-import com.comcast.xconf.firmware.ApplicableAction;
-import com.comcast.xconf.firmware.DefinePropertiesAction;
-import com.comcast.xconf.firmware.FirmwareRule;
-import com.comcast.xconf.firmware.FirmwareRuleTemplate;
+import com.comcast.xconf.firmware.*;
 import com.comcast.xconf.permissions.FirmwarePermissionService;
 import com.comcast.xconf.queries.QueryConstants;
 import com.comcast.xconf.queries.beans.DownloadLocationFilterWrapper;
@@ -1348,7 +1345,7 @@ public class EstbFirmwareControllerTest extends BaseQueriesControllerTest {
         parameters.put(configKey, configValue);
 
         FirmwareConfig firmwareConfig = createFirmwareConfig(defaultFirmwareVersion, defaultModelId, FirmwareConfig.DownloadProtocol.http);
-        firmwareConfig.setParameters(parameters);
+        firmwareConfig.setProperties(parameters);
         firmwareConfigDAO.setOne(firmwareConfig.getId(), firmwareConfig);
 
         createAndSaveUseAccountPercentageBean(firmwareConfig);
@@ -1360,6 +1357,54 @@ public class EstbFirmwareControllerTest extends BaseQueriesControllerTest {
                 .andExpect(status().isOk()).
                 andExpect(jsonPath("$.firmwareVersion").value(firmwareConfig.getFirmwareVersion()))
                 .andExpect(jsonPath("$.bindingUrl").value(configValue));
+    }
+
+    @Test
+    public void firmwareConfigsParametersCanNotBeOverridenByDefinePropertiesRule() throws Exception {
+        Map<String, String> parameters = new HashMap<>();
+        String configKey = "bindingUrl";
+        String configValue = "http://test.url.com";
+        parameters.put(configKey, configValue);
+
+        String definePropertiesModelId = "DEFIDE_PROPERTIES_MODEL_ID";
+        FirmwareConfig firmwareConfig = createFirmwareConfig(defaultFirmwareVersion, definePropertiesModelId, FirmwareConfig.DownloadProtocol.http);
+        firmwareConfig.setProperties(parameters);
+        firmwareConfigDAO.setOne(firmwareConfig.getId(), firmwareConfig);
+
+        PercentageBean percentageBean = createPercentageBean("test percentage bean", defaultEnvironmentId, definePropertiesModelId, null, null, defaultFirmwareVersion, STB);
+        percentageBean.setLastKnownGood(firmwareConfig.getId());
+        percentageBean.getFirmwareVersions().add(firmwareConfig.getFirmwareVersion());
+        percentageBeanQueriesService.save(percentageBean);
+
+        Map<String, String> defineProperties = new HashMap<>();
+        defineProperties.put(configKey, "CHANGED VALUE BY DEFINE PROPERTY RULE");
+        defineProperties.put("definePropertyKey", "definePropertyValue");
+
+        DefinePropertiesTemplateAction definePropertiesTemplateAction = new DefinePropertiesTemplateAction(buildDefinePropertyTemplateAction(defineProperties, false));
+
+        FirmwareRuleTemplate definePropertiesTemplate = createFirmwareRuleTemplate("OVERRIDE_FIRMWARE_CONFIG_PARAMETERS", Rule.Builder.of(new Condition(MODEL, IS, FixedArg.from(definePropertiesModelId))).build(), definePropertiesTemplateAction);
+        firmwareRuleTemplateDao.setOne(definePropertiesTemplate.getId(), definePropertiesTemplate);
+
+        createAndSaveFirmwareRule(UUID.randomUUID().toString(), definePropertiesTemplate.getId(), new DefinePropertiesAction(defineProperties), definePropertiesTemplate.getRule());
+
+        EstbFirmwareContext context = createDefaultContext();
+        context.setFirmwareVersion(defaultFirmwareVersion);
+        context.setModel(definePropertiesModelId);
+
+        mockMvc.perform(postContext("/xconf/swu/stb", context))
+                .andExpect(status().isOk()).
+                andExpect(jsonPath("$.firmwareVersion").value(firmwareConfig.getFirmwareVersion()))
+                .andExpect(jsonPath("$.bindingUrl").value(configValue))
+                .andExpect(jsonPath("$.definePropertyKey").value("definePropertyValue"));
+    }
+
+    private Map<String, DefinePropertiesTemplateAction.PropertyValue> buildDefinePropertyTemplateAction(Map<String, String> parameters, boolean requiredAll) {
+        Map<String, DefinePropertiesTemplateAction.PropertyValue> propertyValues = new HashMap<>();
+        for (Map.Entry<String, String> propertyEntry : parameters.entrySet()) {
+            DefinePropertiesTemplateAction.PropertyValue propertyValue = DefinePropertiesTemplateAction.PropertyValue.create(propertyEntry.getValue(), requiredAll, DefinePropertiesTemplateAction.ValidationType.STRING);
+            propertyValues.put(propertyEntry.getKey(), propertyValue);
+        }
+        return propertyValues;
     }
 
     private PercentageBean createAndSaveUseAccountPercentageBean(FirmwareConfig lkgConfig) {
@@ -1482,7 +1527,7 @@ public class EstbFirmwareControllerTest extends BaseQueriesControllerTest {
         config.setId(null);
         config.setDescription(null);
         config.setSupportedModelIds(null);
-        config.setParameters(null);
+        config.setProperties(null);
         config.setUpdated(null);
         config.setApplicationType(null);
     }

--- a/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesControllerTest.java
+++ b/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesControllerTest.java
@@ -255,8 +255,6 @@ public class FirmwareConfigQueriesControllerTest extends BaseQueriesControllerTe
         assertEquals(firmwareConfig.getProperties(), firmwareConfigDAO.getOne(firmwareConfig.getId()).getProperties());
     }
 
-    public static final long telemetryProfileServiceExpireTimeMs = 1000L;
-
     @Test
     public void createFirmwareConfigWithMoreThanMaxAllowedParametersSize() throws Exception {
         Model model = createAndSaveModel(defaultModelId.toUpperCase());

--- a/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesControllerTest.java
+++ b/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesControllerTest.java
@@ -216,8 +216,8 @@ public class FirmwareConfigQueriesControllerTest extends BaseQueriesControllerTe
 
         mockMvc.perform(get("/" + QueryConstants.QUERIES_FIRMWARES + "/" + firmwareConfig.getId())
                 .accept(MediaType.APPLICATION_JSON)).andExpect(content().json(JsonUtil.toJson(firmwareConfig)))
-                .andExpect(jsonPath("$.properties.testKey").value("testValue"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties.testKey").value("testValue"));
     }
 
     @Test

--- a/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesControllerTest.java
+++ b/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesControllerTest.java
@@ -294,7 +294,7 @@ public class FirmwareConfigQueriesControllerTest extends BaseQueriesControllerTe
     }
 
     @Test
-    public void createFirmwareConfigWithEmptyKeyParameter() throws Exception {
+    public void createFirmwareConfigWithEmptyKey() throws Exception {
         Model model = createAndSaveModel(defaultModelId.toUpperCase());
         FirmwareConfig firmwareConfig = createDefaultFirmwareConfig();
         firmwareConfig.setProperties(Collections.singletonMap("", "testValue"));
@@ -302,7 +302,21 @@ public class FirmwareConfigQueriesControllerTest extends BaseQueriesControllerTe
         mockMvc.perform(post("/" + QueryConstants.UPDATE_FIRMWARES)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtil.toJson(firmwareConfig)))
-                .andExpect(status().isBadRequest()).andExpect(content().string("\"Key is empty\""));
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("\"Key is empty\""));
+    }
+
+    @Test
+    public void createFirmwareConfigWithEmptyValue() throws Exception {
+        Model model = createAndSaveModel(defaultModelId.toUpperCase());
+        FirmwareConfig firmwareConfig = createDefaultFirmwareConfig();
+        firmwareConfig.setProperties(Collections.singletonMap("testKey", ""));
+
+        mockMvc.perform(post("/" + QueryConstants.UPDATE_FIRMWARES)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JsonUtil.toJson(firmwareConfig)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("\"Value is blank for key: testKey\""));
     }
 
     private Map<String, FirmwareConfig> createAndSaveFirmwareConfigs(String stbDescription, String xhomeDescription) throws Exception {

--- a/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesControllerTest.java
+++ b/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/FirmwareConfigQueriesControllerTest.java
@@ -202,17 +202,17 @@ public class FirmwareConfigQueriesControllerTest extends BaseQueriesControllerTe
     @Test
     public void getFirmwareConfigWithParameters() throws Exception {
         Model model = createAndSaveModel(defaultModelId.toUpperCase());
-        Map<String, String> parameters = Collections.singletonMap("testKey", "testValue");
+        Map<String, String> properties = Collections.singletonMap("testKey", "testValue");
 
         FirmwareConfig firmwareConfig = createDefaultFirmwareConfig();
-        firmwareConfig.setParameters(parameters);
+        firmwareConfig.setProperties(properties);
         save(firmwareConfig);
 
         nullifyUnwantedFields(firmwareConfig);
 
         mockMvc.perform(get("/" + QueryConstants.QUERIES_FIRMWARES + "/" + firmwareConfig.getId())
                 .accept(MediaType.APPLICATION_JSON)).andExpect(content().json(JsonUtil.toJson(firmwareConfig)))
-                .andExpect(jsonPath("$.parameters.testKey").value("testValue"))
+                .andExpect(jsonPath("$.properties.testKey").value("testValue"))
                 .andExpect(status().isOk());
     }
 
@@ -222,33 +222,33 @@ public class FirmwareConfigQueriesControllerTest extends BaseQueriesControllerTe
         FirmwareConfig firmwareConfig = createDefaultFirmwareConfig();
         save(firmwareConfig);
 
-        assertTrue(MapUtils.isEmpty(firmwareConfigDAO.getOne(firmwareConfig.getId()).getParameters()));
+        assertTrue(MapUtils.isEmpty(firmwareConfigDAO.getOne(firmwareConfig.getId()).getProperties()));
 
         Map<String, String> parameters = Collections.singletonMap("testKey", "testValue");
 
         FirmwareConfig firmwareConfigToUpdate = new FirmwareConfig(firmwareConfig);
-        firmwareConfigToUpdate.setParameters(parameters);
+        firmwareConfigToUpdate.setProperties(parameters);
 
         mockMvc.perform(put("/" + QueryConstants.UPDATE_FIRMWARES)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtil.toJson(firmwareConfigToUpdate)))
                 .andExpect(status().isOk());
 
-        assertEquals(parameters, firmwareConfigDAO.getOne(firmwareConfigToUpdate.getId()).getParameters());
+        assertEquals(parameters, firmwareConfigDAO.getOne(firmwareConfigToUpdate.getId()).getProperties());
     }
 
     @Test
     public void createFirmwareConfigWithParameters() throws Exception {
         Model model = createAndSaveModel(defaultModelId.toUpperCase());
         FirmwareConfig firmwareConfig = createDefaultFirmwareConfig();
-        firmwareConfig.setParameters(Collections.singletonMap("testKey", "testValue"));
+        firmwareConfig.setProperties(Collections.singletonMap("testKey", "testValue"));
 
         mockMvc.perform(post("/" + QueryConstants.UPDATE_FIRMWARES)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtil.toJson(firmwareConfig)))
                 .andExpect(status().isOk());
 
-        assertEquals(firmwareConfig.getParameters(), firmwareConfigDAO.getOne(firmwareConfig.getId()).getParameters());
+        assertEquals(firmwareConfig.getProperties(), firmwareConfigDAO.getOne(firmwareConfig.getId()).getProperties());
     }
 
     @Test
@@ -257,27 +257,27 @@ public class FirmwareConfigQueriesControllerTest extends BaseQueriesControllerTe
         Map<String, String> parameters = Collections.singletonMap("testKey", "testValue");
 
         FirmwareConfig firmwareConfig = createDefaultFirmwareConfig();
-        firmwareConfig.setParameters(parameters);
+        firmwareConfig.setProperties(parameters);
         save(firmwareConfig);
 
-        assertEquals(parameters, firmwareConfigDAO.getOne(firmwareConfig.getId()).getParameters());
+        assertEquals(parameters, firmwareConfigDAO.getOne(firmwareConfig.getId()).getProperties());
 
         FirmwareConfig firmwareConfigToUpdate = new FirmwareConfig(firmwareConfig);
-        firmwareConfigToUpdate.setParameters(new HashMap<>());
+        firmwareConfigToUpdate.setProperties(new HashMap<>());
 
         mockMvc.perform(put("/" + QueryConstants.UPDATE_FIRMWARES)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtil.toJson(firmwareConfigToUpdate)))
                 .andExpect(status().isOk());
 
-        assertTrue(MapUtils.isEmpty(firmwareConfigDAO.getOne(firmwareConfigToUpdate.getId()).getParameters()));
+        assertTrue(MapUtils.isEmpty(firmwareConfigDAO.getOne(firmwareConfigToUpdate.getId()).getProperties()));
     }
 
     @Test
     public void createFirmwareConfigWithEmptyKeyParameter() throws Exception {
         Model model = createAndSaveModel(defaultModelId.toUpperCase());
         FirmwareConfig firmwareConfig = createDefaultFirmwareConfig();
-        firmwareConfig.setParameters(Collections.singletonMap("", "testValue"));
+        firmwareConfig.setProperties(Collections.singletonMap("", "testValue"));
 
         mockMvc.perform(post("/" + QueryConstants.UPDATE_FIRMWARES)
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Key-value parameters can be specified in Firmware Config. Added following validation to this functionality:
- on UI it is not allowed to save duplicated keys, reason one key-value pair will be overriden by another pair.
- on UI and backend it is not allowed to save FirmwareConfig with an empty key: {"": "some value"}
- empty parameters are allowed

Key-value pair is returned in swu response.