### PR TITLE
FeatureRule is not updated via data service 'importAll' API under xhome application type

### DIFF
--- a/xconf-angular-admin/src/main/webapp/package.json
+++ b/xconf-angular-admin/src/main/webapp/package.json
@@ -7,7 +7,7 @@
     "install": "bower install"
   },
   "dependencies": {
-    "bower": "^1.8.12",
+    "bower": "^1.8.13",
     "cli": "^1.0.1",
     "grunt-cli": "^1.4.3"
   },

--- a/xconf-angular-admin/src/main/webapp/package.json
+++ b/xconf-angular-admin/src/main/webapp/package.json
@@ -7,7 +7,7 @@
     "install": "bower install"
   },
   "dependencies": {
-    "bower": "^1.8.13",
+    "bower": "^1.8.12",
     "cli": "^1.0.1",
     "grunt-cli": "^1.4.3"
   },

--- a/xconf-dataservice/src/main/java/com/comcast/xconf/service/firmware/FirmwareRuleDataService.java
+++ b/xconf-dataservice/src/main/java/com/comcast/xconf/service/firmware/FirmwareRuleDataService.java
@@ -124,6 +124,11 @@ public class FirmwareRuleDataService extends FirmwareRuleService {
         return normalizedMap;
     }
 
+    @Override
+    protected String getWriteApplicationType(FirmwareRule firmwareRule) {
+        return firmwareRule.getApplicationType();
+    }
+
     private Map<String, String> getCustomContextKeys() {
         Map<String, String> contextKeys = new HashMap<>();
         contextKeys.put("applicationType", SearchFields.APPLICATION_TYPE);

--- a/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/BaseQueriesControllerTest.java
+++ b/xconf-dataservice/src/test/java/com/comcast/xconf/queries/controllers/BaseQueriesControllerTest.java
@@ -44,16 +44,11 @@ import com.comcast.xconf.dcm.ruleengine.SettingsDAO;
 import com.comcast.xconf.estbfirmware.*;
 import com.comcast.xconf.estbfirmware.converter.PercentageBeanConverter;
 import com.comcast.xconf.estbfirmware.factory.RuleFactory;
-import com.comcast.xconf.firmware.FirmwareRule;
 import com.comcast.xconf.firmware.*;
 import com.comcast.xconf.logupload.*;
 import com.comcast.xconf.logupload.settings.SettingProfile;
 import com.comcast.xconf.logupload.settings.SettingRule;
-import com.comcast.xconf.logupload.telemetry.PermanentTelemetryProfile;
-import com.comcast.xconf.logupload.telemetry.TelemetryProfile;
-import com.comcast.xconf.logupload.telemetry.TelemetryRule;
-import com.comcast.xconf.logupload.telemetry.TelemetryTwoProfile;
-import com.comcast.xconf.logupload.telemetry.TelemetryTwoRule;
+import com.comcast.xconf.logupload.telemetry.*;
 import com.comcast.xconf.permissions.FirmwarePermissionService;
 import com.comcast.xconf.queries.beans.DownloadLocationFilterWrapper;
 import com.comcast.xconf.rfc.Feature;
@@ -945,7 +940,7 @@ public abstract class BaseQueriesControllerTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("firmwareLocation", "http://1.1.1.1");
         properties.put("firmwareDownloadProtocol", "http");
-        properties.put("ipv6FirmwareLocation", "");
+        properties.put("ipv6FirmwareLocation", "520d:30b1:fd61:064a:dd7b:f7e7:00fb:56ef"); // random ipv6
         action.setProperties(properties);
         return action;
     }


### PR DESCRIPTION
changed validation and calculation `write application type` in data service, now for update API in data service `write application type` is taken from existing entity to not change it accidentally.