### PR TITLE
fixed response error handling if application type is sent in each request

### DIFF
--- a/xconf-angular-admin/src/main/webapp/Gruntfile.js
+++ b/xconf-angular-admin/src/main/webapp/Gruntfile.js
@@ -79,7 +79,8 @@ module.exports = function (grunt) {
                     'node_modules/angular-file-saver/dist/angular-file-saver.bundle.js',
                     'bower_components/angular-ui-select/dist/select.js',
                     'bower_components/google-diff-match-patch/diff_match_patch.js',
-                    'bower_components/angular-diff-match-patch/angular-diff-match-patch.js'
+                    'bower_components/angular-diff-match-patch/angular-diff-match-patch.js',
+                    'node_modules/js-cookie/dist/js.cookie.min.js'
                 ]
             },
 

--- a/xconf-angular-admin/src/main/webapp/WEB-INF/jsp/xconfindex.jsp
+++ b/xconf-angular-admin/src/main/webapp/WEB-INF/jsp/xconfindex.jsp
@@ -85,6 +85,7 @@
             <script src='<c:url value="/bower_components/angular-ui-select/dist/select.js"/>'></script>
             <script src='<c:url value="/bower_components/google-diff-match-patch/diff_match_patch.js"/>'></script>
             <script src='<c:url value="/bower_components/angular-diff-match-patch/angular-diff-match-patch.js"/>'></script>
+            <script src='<c:url value="/node_modules/js-cookie/dist/js.cookie.min.js"/>'></script>
 
             <script src="<c:url value="/app/xconf/app.module.js"/>"></script>
 

--- a/xconf-angular-admin/src/main/webapp/package.json
+++ b/xconf-angular-admin/src/main/webapp/package.json
@@ -22,6 +22,7 @@
     "grunt-open": "^0.2.3",
     "grunt-shell": "^1.1.1",
     "grunt-shell-spawn": "^0.3.0",
+    "js-cookie": "3.0.1",
     "jshint-stylish": "^0.4.0",
     "matchdep": "^0.3.0",
     "remixicon": "^2.5.0"


### PR DESCRIPTION
- application type is sent in every API call as a request parameter except `api/model`, `api/environment`, `api/firmwareruletemplate`, `api/genericnamespacedlist`
- fixed error message handling in UI due to added new interceptor