### PR TITLE
XDPXCONF-173 Change mapping of Telemetry 2.0 profile data service API

### DIFF
--- a/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/TelemetryProfileTwoDataController.java
+++ b/xconf-dataservice/src/main/java/com/comcast/xconf/queries/controllers/TelemetryProfileTwoDataController.java
@@ -39,7 +39,7 @@ import static com.comcast.xconf.queries.controllers.TelemetryProfileTwoDataContr
 @RequestMapping(TELEMETRY_TWO_PROFILE_API)
 public class TelemetryProfileTwoDataController extends BaseQueriesController {
 
-    public static final String TELEMETRY_TWO_PROFILE_API = "/telemetrytwo/profile";
+    public static final String TELEMETRY_TWO_PROFILE_API = "/telemetry/v2/profile";
 
     @Autowired
     private TelemetryProfileTwoDataService telemetryProfileTwoDataService;


### PR DESCRIPTION
changed Telemetry Profile 2.0 data service API mapping from `/telemetrytwo/profile` to `/telemetry/v2/profile`