### PR TITLE
Provide a docker-compose stack for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM docker.io/alpine:latest as initdbpermfix
+
+COPY init-container/init.sh /tmp
+COPY init-container/healthcheck.sh /tmp
+RUN chmod +x /tmp/init.sh && chmod +x /tmp/healthcheck.sh
+
+FROM docker.io/cassandra:4.1.8 as initdb
+COPY --from=initdbpermfix /tmp/init.sh /usr/bin
+COPY --from=initdbpermfix /tmp/healthcheck.sh /usr/bin
+COPY xconf-angular-admin/src/test/resources/schema.cql /tmp
+HEALTHCHECK --start-period=60s CMD "/usr/bin/healthcheck.sh"
+ENTRYPOINT ["/usr/bin/init.sh"]
+
+FROM docker.io/maven:3.9.9-amazoncorretto-8-debian-bookworm as builder
+RUN apt-get -y update && apt-get -y install git
+RUN useradd -m -s /bin/bash build
+COPY . /tmp/build
+RUN chown -R build:build /tmp/build
+USER build
+RUN cd /tmp/build && \
+    cp xconf-angular-admin/src/main/resources/container.service.properties xconf-angular-admin/src/main/resources/service.properties && \
+    cp xconf-dataservice/src/main/resources/container.service.properties xconf-dataservice/src/main/resources/service.properties && \
+    mvn -DskipTests=true clean install
+
+FROM docker.io/jetty:9.4.57-jre8 as angular
+COPY --from=builder /tmp/build/xconf-angular-admin/target/xconfAdminService2.war /var/lib/jetty/webapps/admin.war
+
+FROM docker.io/jetty:9.4.57-jre8 as dataservice
+COPY --from=builder /tmp/build/xconf-dataservice/target/xconf-dataservice.war /var/lib/jetty/webapps/ROOT.war

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 * [Architecture](#architecture)
 * [Run application](#run-application)
     * [Local run](#local-run)
+    * [Using docker-compose](#using-docker-compose)
 * [Configuration](#configuration)
     * [mTLS support](#mtls-support)
 * [Endpoints](#endpoints)
@@ -68,6 +69,46 @@ jetty:run -DappConfig=${path-to-service-properties} -f pom.xml
 ```
 
 NOTE: XConf UI is compiled using `frontend-maven-plugin` during `run` and `install` phase
+
+### Using docker or podman-compose
+
+[docker-compose](https://docs.docker.com/compose/) or
+[podman-compose](https://docs.podman.io/en/latest/markdown/podman-compose.1.html)*
+can be used to quickly create an XConf environment for testing purposes.
+This includes a working Cassandra database server, the Angular-based frontend
+and backend API server.
+
+* `podman-compose` users: please use a recent version of podman-compose (at least `v1.4.0`),
+as earlier versions do not implement the healthcheck based service dependencies
+needed to defer service start until the Cassandara DB is ready.
+
+To bring up the test environment:
+
+```
+# docker-compose
+docker-compose up -d
+# or podman-compose
+podman-compose up -d
+```
+
+The status of the test environment can be viewed with the `ps` subcommand:
+
+```
+$ docker-compose ps
+           Name                         Command                  State                            Ports
+-----------------------------------------------------------------------------------------------------------------------------
+xconfserver_cassandra_1      docker-entrypoint.sh cassa ...   Up (healthy)   7000/tcp, 7001/tcp, 7199/tcp, 9042/tcp, 9160/tcp
+xconfserver_initdb_1         /usr/bin/init.sh                 Up (healthy)   7000/tcp, 7001/tcp, 7199/tcp, 9042/tcp, 9160/tcp
+xconfserver_xconfangular_1   /docker-entrypoint.sh java ...   Up             0.0.0.0:19093->8080/tcp,:::19093->8080/tcp
+xconfserver_xconfdata_1      /docker-entrypoint.sh java ...   Up             0.0.0.0:19092->8080/tcp,:::19092->8080/tcp
+```
+
+The frontend application will be port forwarded from port `19093`, while the API will be forwarded from port `19092`.
+
+The default administrator credentials are `admin/admin`.
+
+Please be aware that the docker-compose file included is only intended for local development use,
+the security settings on the included components are not appropriate for an internet-facing instance.
 
 ## Configuration
 ### mTLS support

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.9'
+
+services:
+  cassandra:
+    image: docker.io/cassandra:4.1.8
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "[ $$(nodetool statusgossip) = running ]"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  initdb:
+    build:
+      context: .
+      target: initdb
+    restart: always
+    depends_on:
+      cassandra:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "/usr/bin/healthcheck.sh"]
+      start_period: 60s
+  xconfangular:
+    build:
+      context: .
+      target: angular
+    ports:
+      - 19093:8080
+    restart: always
+    depends_on:
+      initdb:
+        condition: service_healthy
+  xconfdata:
+    build:
+      context: .
+      target: dataservice
+    ports:
+      - 19092:8080
+    restart: always
+    depends_on:
+      initdb:
+        condition: service_healthy

--- a/init-container/healthcheck.sh
+++ b/init-container/healthcheck.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if (echo 'USE "demo";' | /opt/cassandra/bin/cqlsh cassandra 9042); then
+    exit 0
+else
+    exit 1
+fi

--- a/init-container/init.sh
+++ b/init-container/init.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+cd /opt/cassandra/bin
+
+while true; do
+    if (echo "help" | ./cqlsh cassandra 9042); then
+        # Check database here
+        if (echo 'USE "demo";' | ./cqlsh cassandra 9042); then
+            echo "Database present, exiting"
+            break
+        else
+            echo "No demo database, doing db init"
+            ./cqlsh -f /tmp/schema.cql cassandra 9042
+            echo "Demo schema loaded"
+            break
+        fi
+    else
+        echo "Cassandra not available yet, sleeping 5 seconds"
+        sleep 5
+    fi
+done
+
+# The healthchecks will be a trigger for the
+# docker-compose runtime to start the angular and dataservice
+# containers
+# This container will just sit in the background once it's
+# job is finished.
+while true; do
+    sleep 3600
+done

--- a/xconf-angular-admin/src/main/resources/container.service.properties
+++ b/xconf-angular-admin/src/main/resources/container.service.properties
@@ -1,0 +1,16 @@
+cassandra.keyspaceName=demo
+cassandra.contactPoints=cassandra
+cassandra.username=
+cassandra.password=
+cassandra.port=9042
+cassandra.authKey=
+ 
+dataaccess.cache.tickDuration=60000
+dataaccess.cache.retryCountUntilFullRefresh=10
+dataaccess.cache.changedKeysTimeWindowSize=900000
+dataaccess.cache.reloadCacheEntries=false
+dataaccess.cache.reloadCacheEntriesTimeout=1
+dataaccess.cache.reloadCacheEntriesTimeUnit=DAYS
+dataaccess.cache.numberOfEntriesToProcessSequentially=10000
+dataaccess.cache.keysetChunkSizeForMassCacheLoad=500
+dataaccess.cache.changedKeysCfName=XconfChangedKeys4

--- a/xconf-dataservice/src/main/resources/container.service.properties
+++ b/xconf-dataservice/src/main/resources/container.service.properties
@@ -1,0 +1,16 @@
+cassandra.keyspaceName=demo
+cassandra.contactPoints=cassandra
+cassandra.username=
+cassandra.password=
+cassandra.port=9042
+cassandra.authKey=
+ 
+dataaccess.cache.tickDuration=60000
+dataaccess.cache.retryCountUntilFullRefresh=10
+dataaccess.cache.changedKeysTimeWindowSize=900000
+dataaccess.cache.reloadCacheEntries=false
+dataaccess.cache.reloadCacheEntriesTimeout=1
+dataaccess.cache.reloadCacheEntriesTimeUnit=DAYS
+dataaccess.cache.numberOfEntriesToProcessSequentially=10000
+dataaccess.cache.keysetChunkSizeForMassCacheLoad=500
+dataaccess.cache.changedKeysCfName=XconfChangedKeys4


### PR DESCRIPTION
I hope this is useful to somebody.

This adds a docker-compose stack and supporting container files to run a working XConf instance.

The configuration is similar to the steps described on [wiki.rdkcentral.com](https://wiki.rdkcentral.com/display/RDK/Xconf+Server+-+User+guide+for+configuration+and+feature+validation#XconfServerUserguideforconfigurationandfeaturevalidation-ConfigurationandServicestartup) and should not be relied upon for production purposes without modification.

```
CONTAINER ID  IMAGE                                      COMMAND               CREATED     STATUS      PORTS                    NAMES
bf2d170e8002  docker.io/library/cassandra:4.1.8          cassandra -f          6 days ago  Created                              xconfserver_cassandra_1
3d518b33afd9  localhost/xconfserver_initdb:latest                              6 days ago  Created                              xconfserver_initdb_1
233d7a02abd3  localhost/xconfserver_xconfangular:latest  java -jar /usr/lo...  6 days ago  Created     0.0.0.0:19093->8080/tcp  xconfserver_xconfangular_1
0201c9dd85a8  localhost/xconfserver_xconfdata:latest     java -jar /usr/lo...  6 days ago  Created     0.0.0.0:19092->8080/tcp  xconfserver_xconfdata_1
```
Tested hosts:

- docker-compose 1.29.2 / docker 24 on Linux/x86_64
- podman-compose 1.4.0 / podman 4.9.3 on Linux/arm64